### PR TITLE
Don't require rubocop when gem is instantiated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.bundle/
 /Gemfile.lock
+govuk-lint-*.gem

--- a/bin/govuk-lint-ruby
+++ b/bin/govuk-lint-ruby
@@ -3,7 +3,7 @@
 lib = File.expand_path("../../lib", __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
-require "govuk/lint"
+require "govuk/lint/cli"
 
 cli = Govuk::Lint::CLI.new
 

--- a/lib/govuk/lint.rb
+++ b/lib/govuk/lint.rb
@@ -1,6 +1,4 @@
 require "govuk/lint/version"
-require "govuk/lint/cli"
-require "govuk/lint/diff"
 
 module Govuk
   module Lint

--- a/lib/govuk/lint/cli.rb
+++ b/lib/govuk/lint/cli.rb
@@ -1,3 +1,6 @@
+require "govuk/lint"
+require "govuk/lint/diff"
+
 require "rubocop"
 
 module Govuk


### PR DESCRIPTION
Previously, bundler would do `require "govuk/lint"` which would load in
Rubocop. This will automatically produce warnings like:

```
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.7-compliant syntax, but you are running 2.1.6.
```
