### PR TITLE
Escape linebreaks properly in the difftool command

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,6 +6,7 @@ git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 bundle exec bin/govuk-lint-ruby lib bin/govuk-lint-ruby
+bundle exec bin/govuk-lint-ruby lib bin/govuk-lint-ruby --diff
 
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle exec rake publish_gem

--- a/lib/govuk/lint/diff.rb
+++ b/lib/govuk/lint/diff.rb
@@ -25,12 +25,12 @@ module Govuk
         @changed_lines ||= begin
           changes = changed_files.map do |file|
             next unless File.exist?(file)
-            [file, `git difftool #{commit_options}
-                    -y
-                    -x 'diff
-                      --new-line-format="%dn "
-                      --unchanged-line-format=""
-                      --changed-group-format="%>"'
+            [file, `git difftool #{commit_options} \
+                    -y \
+                    -x 'diff \
+                      --new-line-format="%dn " \
+                      --unchanged-line-format="" \
+                      --changed-group-format="%>"' \
                     #{file}`.split.map(&:to_i)]
           end
 


### PR DESCRIPTION
Implicit linebreaks in the backticked command line don't seem to work in all Ruby versions, so we should be explicit about escaping linebreaks.
This was making Whitehall builds hang.
