### PR TITLE
Disable the line-length check.

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -49,7 +49,7 @@ IndentationConsistency:
 
 LineLength:
   Description: Limit lines to 80 characters.
-  Enabled: true
+  Enabled: false
   Max: 80
 
 # Supports --auto-correct


### PR DESCRIPTION
There are occasions where following this rule forces you to make the
code less readable. This is particularly the case for tests where method
names form the test descriptions. Keeping test descriptions under a
certain length can force them to become cryptic.

In line with the intro to the styleguide, this therefore isn't something
that's appropriate to enforce automatically.
