### PR TITLE
Don't enforce double-quotes for strings.

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -311,7 +311,7 @@ StringConversionInInterpolation:
 # Supports --auto-correct
 StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
-  Enabled: true
+  Enabled: false
   EnforcedStyle: double_quotes
   SupportedStyles:
   - single_quotes


### PR DESCRIPTION
There are times when it's appropriate to use single quotes.
Specifically when maintaining consistency within an area of the
codebase (this linter it typically only applied to the diffs, and
therefore won't take into account existing uses of single-quotes - eg
https://github.com/alphagov/whitehall/pull/2270).  It therefore doesn't
make sense to enforce this automatically.
