### PR TITLE
More lenient on multi-line operations

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -209,6 +209,9 @@ ModuleFunction:
   Description: 'Checks for usage of `extend self` in modules.'
   Enabled: false
 
+MultilineOperationIndentation:
+  EnforcedStyle: indented
+
 NegatedIf:
   Description: >-
     Favor unless over if for negative conditions


### PR DESCRIPTION
Allows this:

```
    raise NotAuthorizedError if current_user &&
        ! current_user.admin?
```

instead of this:

```
    raise NotAuthorizedError if current_user &&
                                ! current_user.admin?
```
