### PR TITLE
Combine --diff and --cached options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ Useful options:
 
 - `-a`: Auto-correct violations if possible
 - `-R`: Also run Rails-specific cops
-- `--diff`: Only lint lines that have been changed in the current diff
-- `--cached`: Used with `--diff` to lint only lines changed between
-`origin/master` and `HEAD`.
+- `--diff`: Only lint lines that have been changed in the current diff, including any staged (cached) changes. This is useful for Jenkins where we merge (but don't commit) changes from origin/master in to our branch.
 
 See more options in the [rubocop][rubocop] README.
 

--- a/lib/govuk/lint/diff.rb
+++ b/lib/govuk/lint/diff.rb
@@ -16,7 +16,6 @@ module Govuk
 
       def self.enable!(args)
         args.delete("--diff")
-        @cached = true if args.delete("--cached")
         RuboCop::Cop::Cop.prepend EnabledLines
         RuboCop::TargetFinder.prepend TargetFinder
       end
@@ -47,7 +46,7 @@ module Govuk
       end
 
       def self.commit_options
-        @cached ? "--cached origin/master" : "origin/master HEAD"
+        "--cached origin/master"
       end
     end
   end


### PR DESCRIPTION
As far as I can tell, the `--cached` option is designed to be used on CI where
we first merge changes from origin/master to our branch before running our
tests. If we were just to use the `--diff` option then we'd also end up linting
files that have been changed in master since our branch was created.

Having played with both the `--diff` and `--cached` options it looks as though
`--cached` will _always_ do what `--diff` does, but with the additional benefit
of working correctly on CI. As such, I propose we combine these options into
one.
