### PR TITLE
Consider all changed files in changed_files method

### DIFF
--- a/lib/govuk/lint/diff.rb
+++ b/lib/govuk/lint/diff.rb
@@ -42,7 +42,6 @@ module Govuk
       def self.changed_files
         `git diff #{commit_options} --name-only`.
           split.
-          select { |f| f =~ %r{.rb$} }.
           map { |f| File.expand_path(f.chomp, "./") }
       end
 


### PR DESCRIPTION
Remove the `.select {}` method that restricted the `.changed_files` method to
".rb" files only.

I know that my Gemfile contains violations of the GOV.UK Styleguide codified in
the included Cops. I was surprised that `govuk-lint-ruby` didn't report on
these violations when I used the `--diff` option, even though I'd made a change
to the Gemfile in my branch.

It doesn't feel right to me that `govuk-lint-ruby --diff` is restricted to
".rb" files when `govuk-lint-ruby` isn't.
