### PR TITLE
Respect local .rubocop.yml

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Respect local `.rubocop.yml` files
+
 # 0.3.0
 
 * Allow single indentation in Multiline operations

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,10 @@ task :publish_gem do |t|
   gem = GemPublisher.publish_if_updated("govuk-lint.gemspec", :rubygems)
   puts "Published #{gem}" if gem
 end
+
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :test => :spec
+task :default => :test

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "gem_publisher", "1.5.0"
+  spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop", "~> 0.32"
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -8,6 +8,8 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec bin/govuk-lint-ruby lib bin/govuk-lint-ruby
 bundle exec bin/govuk-lint-ruby lib bin/govuk-lint-ruby --diff
 
+bundle exec rake test
+
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle exec rake publish_gem
 fi

--- a/lib/govuk/lint.rb
+++ b/lib/govuk/lint.rb
@@ -2,6 +2,5 @@ require "govuk/lint/version"
 
 module Govuk
   module Lint
-    CONFIG_PATH = File.expand_path("../../../configs", __FILE__)
   end
 end

--- a/lib/govuk/lint/cli.rb
+++ b/lib/govuk/lint/cli.rb
@@ -1,5 +1,6 @@
 require "govuk/lint"
 require "govuk/lint/diff"
+require "govuk/lint/config_file"
 
 require "rubocop"
 
@@ -8,7 +9,7 @@ module Govuk
     class CLI < RuboCop::CLI
       def run(args = ARGV)
         args += ["--config",
-                 File.join(Govuk::Lint::CONFIG_PATH, "rubocop/all.yml")]
+                 ConfigFile.new.config_file_path]
 
         Diff.enable!(args) if args.include? "--diff"
 

--- a/lib/govuk/lint/config_file.rb
+++ b/lib/govuk/lint/config_file.rb
@@ -1,0 +1,49 @@
+require 'tempfile'
+require 'yaml'
+
+module Govuk
+  module Lint
+    class ConfigFile
+      CONFIG_PATH = File.expand_path("../../../../configs", __FILE__)
+      BASE_CONFIG_FILE = File.join(CONFIG_PATH, "rubocop/all.yml")
+
+      def config_file_path
+        return BASE_CONFIG_FILE unless File.exist?(local_config_file_path)
+
+        config = merged_global_and_local_configs
+        file = create_tempfile_for_configs(config)
+        file.path
+      end
+
+    private
+
+      def merged_global_and_local_configs
+        config = load_global_config
+        config['inherit_from'] = absolutize_paths(config)
+        config['inherit_from'] << local_config_file_path
+        config
+      end
+
+      def load_global_config
+        YAML.load_file(BASE_CONFIG_FILE)
+      end
+
+      def absolutize_paths(config)
+        config['inherit_from'].map do |filename|
+          File.join(CONFIG_PATH, "rubocop/#{filename}")
+        end
+      end
+
+      def local_config_file_path
+        @local_config_file_path ||= File.join(Dir.pwd, ".rubocop.yml")
+      end
+
+      def create_tempfile_for_configs(config)
+        file = Tempfile.new('tmp-rubocop-all.yml')
+        file.write(config.to_yaml)
+        file.close
+        file
+      end
+    end
+  end
+end

--- a/spec/lib/config_file_spec.rb
+++ b/spec/lib/config_file_spec.rb
@@ -1,0 +1,22 @@
+require "govuk/lint/config_file"
+
+RSpec.describe Govuk::Lint::ConfigFile do
+  describe '#config_file_path' do
+    it 'defaults to our all.yml' do
+      path = Govuk::Lint::ConfigFile.new.config_file_path
+
+      expect(path).to eql Govuk::Lint::ConfigFile::BASE_CONFIG_FILE
+    end
+
+    it 'includes the local .rubocop.yml in the temporary' do
+      cli = Govuk::Lint::ConfigFile.new
+      local_rubocop_file = Tempfile.new('.rubocop.yml').path
+      allow(cli).to receive(:local_config_file_path).and_return(local_rubocop_file)
+
+      file = YAML.load_file(cli.config_file_path)
+
+      expect(file['inherit_from']).to include(local_rubocop_file)
+      expect(file['inherit_from'].size > 1).to eql(true)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.disable_monkey_patching!
+  config.warnings = true
+
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  config.order = :random
+
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
Projects should be allowed to override the Ruby styleguide.  This PR makes `govuk-lint` respect any local `.rubocop.yml` file. 

When a `.rubocop.yml` file is found in the current directory, we add that config to the `inherits_from` in govuk-lint's original config (we need a temporary file for this).

This means that the rules in the local file take precedence over the ones in this repo.

The immediate use case is to start experimenting with enabling a bunch of useful cops that are currently disabled. I'm also looking into custom GOV.UK cops that check things like [not having sessions enabled](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+user%3Aalphagov+disable+sessions).

Fixes https://github.com/alphagov/govuk-lint/issues/14
