### PR TITLE
Allow trivial predicates

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -231,7 +231,7 @@ TrivialAccessors:
   Description: Prefer attr_* methods to trivial readers/writers.
   Enabled: true
   ExactNameMatch: true
-  AllowPredicates: false
+  AllowPredicates: true
   AllowDSLWriters: false
   Whitelist:
   - to_ary


### PR DESCRIPTION
A regular trivial predicate:

``` ruby
def thing?
  @thing
end
```

This currently trips the `AllowPredicates` cop. The workaround seems
like unnecessary gymnastics just to achieve the same end:

``` ruby
attr_reader :thing
alias :thing? :thing
```

This change will permit trivial predicates of the prior form.
