### PR TITLE
Enable all the lint checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Enable all lint checks
+
 # 0.4.1
 
 * Permit trivial predicates (#19)

--- a/configs/rubocop/other-lint.yml
+++ b/configs/rubocop/other-lint.yml
@@ -2,130 +2,130 @@ AmbiguousOperator:
   Description: >-
      Checks for ambiguous operators in the first argument of a
      method invocation without parentheses.
-  Enabled: false
+  Enabled: true
 
 AmbiguousRegexpLiteral:
   Description: >-
     Checks for ambiguous regexp literals in the first argument of
     a method invocation without parenthesis.
-  Enabled: false
+  Enabled: true
 
 AssignmentInCondition:
   Description: "Don't use assignment in conditions."
-  Enabled: false
+  Enabled: true
 
 ConditionPosition:
   Description: 'Checks for condition placed in a confusing position relative to the keyword.'
-  Enabled: false
+  Enabled: true
 
 Debugger:
   Description: 'Check for debugger calls.'
-  Enabled: false
+  Enabled: true
 
 DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
-  Enabled: false
+  Enabled: true
 
 EmptyEnsure:
   Description: 'Checks for empty ensure block.'
-  Enabled: false
+  Enabled: true
 
 EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
-  Enabled: false
+  Enabled: true
 
 EndInMethod:
   Description: 'END blocks should not be placed inside method definitions.'
-  Enabled: false
+  Enabled: true
 
 EnsureReturn:
   Description: 'Never use return in an ensure block.'
-  Enabled: false
+  Enabled: true
 
 Eval:
   Description: 'The use of eval represents a serious security risk.'
-  Enabled: false
+  Enabled: true
 
 HandleExceptions:
   Description: "Don't suppress exception."
-  Enabled: false
+  Enabled: true
 
 InvalidCharacterLiteral:
   Description: >-
      Checks for invalid character literals with a non-escaped
      whitespace character.
-  Enabled: false
+  Enabled: true
 
 LiteralInCondition:
   Description: 'Checks of literals used in conditions.'
-  Enabled: false
+  Enabled: true
 
 LiteralInInterpolation:
   Description: 'Checks for literals used in interpolation.'
-  Enabled: false
+  Enabled: true
 
 Loop:
   Description: >-
      Use Kernel#loop with break rather than begin/end/until or
      begin/end/while for post-loop tests.
-  Enabled: false
+  Enabled: true
 
 ParenthesesAsGroupedExpression:
   Description: >-
      Checks for method calls with a space before the opening
      parenthesis.
-  Enabled: false
+  Enabled: true
 
 RequireParentheses:
   Description: >-
      Use parentheses in the method call to avoid confusion
      about precedence.
-  Enabled: false
+  Enabled: true
 
 ShadowingOuterLocalVariable:
   Description: >-
      Do not use the same name as outer local variable
      for block arguments or block local variables.
-  Enabled: false
+  Enabled: true
 
 SpaceBeforeFirstArg:
   Description: >-
      Put a space between a method name and the first argument
      in a method call without parentheses.
-  Enabled: false
+  Enabled: true
 
 UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
-  Enabled: false
+  Enabled: true
 
 UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
-  Enabled: false
+  Enabled: true
 
 UnreachableCode:
   Description: 'Unreachable code.'
-  Enabled: false
+  Enabled: true
 
 UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
-  Enabled: false
+  Enabled: true
 
 UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'
-  Enabled: false
+  Enabled: true
 
 UselessComparison:
   Description: 'Checks for comparison of something with itself.'
-  Enabled: false
+  Enabled: true
 
 UselessElseWithoutRescue:
   Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
-  Enabled: false
+  Enabled: true
 
 UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
-  Enabled: false
+  Enabled: true
 
 Void:
   Description: 'Possible use of operator/literal/variable in void context.'
-  Enabled: false
+  Enabled: true


### PR DESCRIPTION
Lint checks are the most useful feature of Rubocop. They check for signs code is actually broken, not just of it's formatted correctly. Cops like `UnreachableCode` and `UselessAssignment` point to bugs in most cases.

I believe these cops were perhaps never meant to be disabled. There will possibly be cops we do not want  to enable, but those will probably be fewer than the ones we like.  Therefore this commit enables
them _all_.
