### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.5.0
+
 * Enable all lint checks
 
 # 0.4.1

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "0.4.1"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
Enables all the lint checks (https://github.com/alphagov/govuk-lint/pull/21).
