### PR TITLE
Show more info for violations

### DIFF
--- a/lib/govuk/lint/cli.rb
+++ b/lib/govuk/lint/cli.rb
@@ -9,7 +9,11 @@ module Govuk
     class CLI < RuboCop::CLI
       def run(args = ARGV)
         args += ["--config",
-                 ConfigFile.new.config_file_path]
+                 ConfigFile.new.config_file_path,
+                 "--display-cop-names",
+                 "--extra-details",
+                 "--display-style-guide",
+                ]
 
         Diff.enable!(args) if args.include? "--diff"
 


### PR DESCRIPTION
Before:

```
app.rb:41:5: C: Replace class var @@registries with a class instance
var.
    @@registries ||= Registries.new(
    ^^^^^^^^^^^^
```

After:

```
app.rb:41:5: C: Style/ClassVars: Replace class var @@registries with a
class instance var.
(https://github.com/bbatsov/ruby-style-guide#no-class-vars)
    @@registries ||= Registries.new(
    ^^^^^^^^^^^^
```
