### PR TITLE
Enable access modifier cops to match styleguide

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -122,7 +122,7 @@ EachWithObject:
 
 EmptyLinesAroundAccessModifier:
   Description: "Keep blank lines around access modifiers."
-  Enabled: false
+  Enabled: true
 
 EmptyLines:
   Description: "Keeps track of empty lines around expression bodies."

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -1,6 +1,7 @@
 AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: outdent
 
 AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "gem_publisher", "1.5.0"
   spec.add_development_dependency "rspec", "~> 3.3"
 
-  spec.add_dependency "rubocop", "~> 0.32"
+  spec.add_dependency "rubocop", "~> 0.35.0"
 end

--- a/lib/govuk/lint/diff.rb
+++ b/lib/govuk/lint/diff.rb
@@ -39,6 +39,7 @@ module Govuk
       end
 
     private
+
       def self.changed_files
         `git diff #{commit_options} --name-only`.
           split.


### PR DESCRIPTION
Our styleguide says to outdent and leave surrounding blank lines (see alphagov/styleguides#83), so we should enforce these rules with the available cops.
