### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.5.1
+
+* Update rubocop dependency to ~> 0.35.0
+* Enable outdent for access modifiers
+* Enable blank lines around access modifiers
+* Show more infos for violations
+
 # 0.5.0
 
 * Enable all lint checks

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end


### PR DESCRIPTION
Update rubocop dependency to ~> 0.35.0 (#24)
Enable outdent for access modifiers (#24)
Enable blank lines around access modifiers (#24)
Show more infos for violations (#23)
