### PR TITLE
Enforce spaces around braces

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -60,7 +60,7 @@ BlockDelimiters:
 
 BracesAroundHashParameters:
   Description: 'Enforce braces style inside hash parameters.'
-  Enabled: false
+  Enabled: true
 
 CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'


### PR DESCRIPTION
The styleguide says:

```
Use spaces around operators, after commas, colons and semicolons,
around { and before }
```

But the `BracesAroundHashParameters` cop is disabled. We should enable
this for consistency.
