### PR TITLE
Enforce spaces around braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.2
 
-* Enforce spaces around braces `BracesAroundHashParameters` cop (#26)
+* Don't permit braces for options-style hash params
+  `BracesAroundHashParameters` cop (#26)
 
 # 0.5.1
 

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -342,7 +342,7 @@ SpaceInsideBlockBraces:
     Checks that block braces have or don't have surrounding space.
     For blocks taking parameters, checks that the left brace has
     or doesn't have trailing space.
-  Enabled: false
+  Enabled: true
 
 SpaceBeforeModifierKeyword:
   Description: 'Put a space before the modifier keyword.'
@@ -350,7 +350,7 @@ SpaceBeforeModifierKeyword:
 
 SpaceInsideHashLiteralBraces:
   Description: "Use spaces inside hash literal braces - or don't."
-  Enabled: false
+  Enabled: true
 
 SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'


### PR DESCRIPTION
Unfortunately, d62b6a5 enabled the wrong cop. The
`BracesAroundHashParameters` is guidance for wrapping or not wrapping
options-style parameters in method calls. While incorrect, it still fits in
with our styleguide so can remain enabled.

The correct cops for spacing around block or literal hash braces are
`SpacesInsideBlockBraces` and `SpaceInsideLiteralHashBraces` respectively.

The styleguide says:

> Use spaces around operators, after commas, colons and
>  semicolons, around { and before }

So I am enabling these cops to enforce our style guidance.

I've also corrected the changelog entry for v0.5.2, (#26)
