### PR TITLE
Release `0.5.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.3
+
+* Enforce spaces around literal hash and block braces (#27)
+
 # 0.5.2
 
 * Don't permit braces for options-style hash params

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "0.5.2"
+    VERSION = "0.5.3"
   end
 end


### PR DESCRIPTION
Enforce spaces around literal hash and block braces (#27)
