### PR TITLE
Add Sass linting

### DIFF
--- a/bin/govuk-lint-sass
+++ b/bin/govuk-lint-sass
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path("../../lib", __FILE__)
+$:.unshift lib unless $:.include?(lib)
+
+require 'govuk/lint/sass_cli'
+require 'scss_lint/logger'
+
+logger = SCSSLint::Logger.new(STDOUT)
+
+cli = Govuk::Lint::SassCLI.new(logger)
+exit cli.run

--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -1,0 +1,245 @@
+# Default application configuration that all configurations inherit from.
+
+scss_files: "**/*.scss"
+plugin_directories: ['.scss-linters']
+
+# List of gem names to load custom linters from (make sure they are already
+# installed)
+plugin_gems: []
+
+# Default severity of all linters.
+severity: warning
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BemDepth:
+    enabled: false
+    max_elements: 1
+
+  BorderZero:
+    enabled: true
+    convention: zero # or `none`
+
+  ChainedClasses:
+    enabled: false
+
+  ColorKeyword:
+    enabled: true
+
+  ColorVariable:
+    enabled: true
+
+  Comment:
+    enabled: true
+    style: silent
+
+  DebugStatement:
+    enabled: true
+
+  DeclarationOrder:
+    enabled: true
+
+  DisableLinterReason:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: true
+
+  ElsePlacement:
+    enabled: true
+    style: same_line # or 'new_line'
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+
+  EmptyRule:
+    enabled: true
+
+  ExtendDirective:
+    enabled: false
+
+  FinalNewline:
+    enabled: true
+    present: true
+
+  HexLength:
+    enabled: true
+    style: short # or 'long'
+
+  HexNotation:
+    enabled: true
+    style: lowercase # or 'uppercase'
+
+  HexValidation:
+    enabled: true
+
+  IdSelector:
+    enabled: true
+
+  ImportantRule:
+    enabled: true
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space # or 'tab'
+    width: 2
+
+  LeadingZero:
+    enabled: true
+    style: exclude_zero # or 'include_zero'
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+
+  NestingDepth:
+    enabled: true
+    max_depth: 3
+    ignore_parent_selectors: false
+
+  PlaceholderInExtend:
+    enabled: true
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
+
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+    disabled_properties: []
+
+  PropertyUnits:
+    enabled: true
+    global: [
+      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',            # Angle
+      'ms', 's',                               # Duration
+      'Hz', 'kHz',                             # Frequency
+      'dpi', 'dpcm', 'dppx',                   # Resolution
+      '%']                                     # Other
+    properties: {}
+
+  PseudoElement:
+    enabled: true
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 3
+
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2, 3]
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+
+  SingleLinePerSelector:
+    enabled: true
+
+  SpaceAfterComma:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space'
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+
+  SpaceAfterPropertyName:
+    enabled: true
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space # or 'at_least_one_space', or 'no_space'
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space # or 'new_line'
+    allow_single_line_padding: false
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+
+  StringQuotes:
+    enabled: true
+    style: single_quotes # or double_quotes
+
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  TrailingZero:
+    enabled: false
+
+  TransitionAll:
+    enabled: false
+
+  UnnecessaryMantissa:
+    enabled: true
+
+  UnnecessaryParentReference:
+    enabled: true
+
+  UrlFormat:
+    enabled: true
+
+  UrlQuotes:
+    enabled: true
+
+  VariableForProperty:
+    enabled: false
+    properties: []
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+
+  ZeroUnit:
+    enabled: true
+
+  Compass::*:
+    enabled: false

--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -96,8 +96,8 @@ linters:
 
   NestingDepth:
     enabled: true
-    max_depth: 3
-    ignore_parent_selectors: false
+    max_depth: 5 # ideally 3
+    ignore_parent_selectors: true
 
   PlaceholderInExtend:
     enabled: true

--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -60,7 +60,7 @@ linters:
     enabled: false
 
   HexNotation:
-    enabled: true
+    enabled: false # colours should be variables
     style: lowercase
 
   HexValidation:

--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -1,12 +1,3 @@
-# Default application configuration that all configurations inherit from.
-
-scss_files: "**/*.scss"
-plugin_directories: ['.scss-linters']
-
-# List of gem names to load custom linters from (make sure they are already
-# installed)
-plugin_gems: []
-
 # Default severity of all linters.
 severity: warning
 
@@ -18,11 +9,9 @@ linters:
 
   BemDepth:
     enabled: false
-    max_elements: 1
 
   BorderZero:
-    enabled: true
-    convention: zero # or `none`
+    enabled: false
 
   ChainedClasses:
     enabled: false
@@ -41,7 +30,7 @@ linters:
     enabled: true
 
   DeclarationOrder:
-    enabled: true
+    enabled: false
 
   DisableLinterReason:
     enabled: false
@@ -51,7 +40,7 @@ linters:
 
   ElsePlacement:
     enabled: true
-    style: same_line # or 'new_line'
+    style: same_line
 
   EmptyLineBetweenBlocks:
     enabled: true
@@ -68,12 +57,11 @@ linters:
     present: true
 
   HexLength:
-    enabled: true
-    style: short # or 'long'
+    enabled: false
 
   HexNotation:
     enabled: true
-    style: lowercase # or 'uppercase'
+    style: lowercase
 
   HexValidation:
     enabled: true
@@ -82,7 +70,7 @@ linters:
     enabled: true
 
   ImportantRule:
-    enabled: true
+    enabled: false
 
   ImportPath:
     enabled: true
@@ -92,21 +80,19 @@ linters:
   Indentation:
     enabled: true
     allow_non_nested_indentation: false
-    character: space # or 'tab'
+    character: space
     width: 2
 
   LeadingZero:
-    enabled: true
-    style: exclude_zero # or 'include_zero'
+    enabled: false
 
   MergeableSelector:
-    enabled: true
-    force_nesting: true
+    enabled: false
 
   NameFormat:
     enabled: true
     allow_leading_underscore: true
-    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+    convention: hyphenated_lowercase
 
   NestingDepth:
     enabled: true
@@ -118,49 +104,31 @@ linters:
 
   PropertyCount:
     enabled: false
-    include_nested: false
-    max_properties: 10
 
   PropertySortOrder:
-    enabled: true
-    ignore_unspecified: false
-    min_properties: 2
-    separate_groups: false
+    enabled: false
 
   PropertySpelling:
-    enabled: true
-    extra_properties: []
-    disabled_properties: []
+    enabled: false # avoid false positives on new CSS features
 
   PropertyUnits:
-    enabled: true
-    global: [
-      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
-      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
-      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
-      'deg', 'grad', 'rad', 'turn',            # Angle
-      'ms', 's',                               # Duration
-      'Hz', 'kHz',                             # Frequency
-      'dpi', 'dpcm', 'dppx',                   # Resolution
-      '%']                                     # Other
-    properties: {}
+    enabled: false
 
   PseudoElement:
-    enabled: true
+    enabled: false # using `:after` is acceptable for older browsers
 
   QualifyingElement:
     enabled: true
-    allow_element_with_attribute: false
+    allow_element_with_attribute: true # eg elements based on aria attributes
     allow_element_with_class: false
     allow_element_with_id: false
 
   SelectorDepth:
-    enabled: true
-    max_depth: 3
+    enabled: false
 
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+    convention: hyphenated_lowercase
 
   Shorthand:
     enabled: true
@@ -175,11 +143,11 @@ linters:
 
   SpaceAfterComma:
     enabled: true
-    style: one_space # or 'no_space', or 'at_least_one_space'
+    style: one_space
 
   SpaceAfterPropertyColon:
     enabled: true
-    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+    style: one_space
 
   SpaceAfterPropertyName:
     enabled: true
@@ -189,20 +157,18 @@ linters:
 
   SpaceAroundOperator:
     enabled: true
-    style: one_space # or 'at_least_one_space', or 'no_space'
+    style: one_space
 
   SpaceBeforeBrace:
     enabled: true
-    style: space # or 'new_line'
-    allow_single_line_padding: false
+    style: space
+    allow_single_line_padding: true
 
   SpaceBetweenParens:
-    enabled: true
-    spaces: 0
+    enabled: false
 
   StringQuotes:
-    enabled: true
-    style: single_quotes # or double_quotes
+    enabled: false
 
   TrailingSemicolon:
     enabled: true
@@ -211,10 +177,10 @@ linters:
     enabled: true
 
   TrailingZero:
-    enabled: false
+    enabled: true
 
   TransitionAll:
-    enabled: false
+    enabled: true
 
   UnnecessaryMantissa:
     enabled: true
@@ -233,10 +199,7 @@ linters:
     properties: []
 
   VendorPrefix:
-    enabled: true
-    identifier_list: base
-    additional_identifiers: []
-    excluded_identifiers: []
+    enabled: false
 
   ZeroUnit:
     enabled: true

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop", "~> 0.35.0"
+  spec.add_dependency "scss_lint", "~> 0.44.0"
 end

--- a/lib/govuk/lint.rb
+++ b/lib/govuk/lint.rb
@@ -2,5 +2,6 @@ require "govuk/lint/version"
 
 module Govuk
   module Lint
+    CONFIG_PATH = File.expand_path("../../../configs", __FILE__)
   end
 end

--- a/lib/govuk/lint/sass_cli.rb
+++ b/lib/govuk/lint/sass_cli.rb
@@ -1,0 +1,21 @@
+require "govuk/lint"
+require "scss_lint"
+require "scss_lint/cli"
+
+module Govuk
+  module Lint
+    class SassCLI < SCSSLint::CLI
+      def run(args = ARGV)
+        args += [
+                  "--config",
+                  File.join(Govuk::Lint::CONFIG_PATH, "scss_lint/gds-sass-styleguide.yml"),
+                  "--no-color",
+                  "--exclude",
+                  File.join(args.first, "**/vendor/*"),
+                ]
+
+        super(args)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Begin using SCSS Lint to lint our style files:
https://github.com/brigade/scss-lint
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md
- Decisions that vary from the default `scss-lint` config (which is a good default) are recorded in 954b564
- [CSS guidance](https://github.com/alphagov/styleguides/blob/master/css.md) in the style guide is quite minimal, based on these linting rules that should also be updated.
- The rules should be a balance of legible, readable code and also highlighting the worst offences (eg highly nested rules)

Example output:

```
../government-frontend/app/assets/stylesheets/helpers/_available-languages.scss:23 [W] SingleLinePerSelector: Each selector in a comma sequence should be on its own single line
../government-frontend/app/assets/stylesheets/helpers/_available-languages.scss:27 [W] EmptyLineBetweenBlocks: Rule declaration should be followed by an empty line
../government-frontend/app/assets/stylesheets/helpers/_available-languages.scss:36 [W] EmptyLineBetweenBlocks: Rule declaration should be preceded by an empty line
../government-frontend/app/assets/stylesheets/helpers/_dash-list.scss:12 [W] EmptyLineBetweenBlocks: Rule declaration should be preceded by an empty line
../government-frontend/app/assets/stylesheets/helpers/_dash-list.scss:17 [W] SpaceAroundOperator: `$gutter-half*-1` should be written with a single space on each side of the operator: `$gutter-half *- 1`
```

Differences with rubocop:
- Lacks `diff` only linting
- Can't pass in multiple file directories

cc @dsingleton @tombye @gemmaleigh @benlovell 
