### PR TITLE
Add guard to rubocop instance var

### DIFF
--- a/lib/govuk/lint/diff.rb
+++ b/lib/govuk/lint/diff.rb
@@ -3,10 +3,10 @@ module Govuk
     module Diff
       module EnabledLines
         def enabled_line?(line_number)
-          return true unless @processed_source
+          return true unless processed_source
 
           super(line_number) &&
-            Diff.changed_lines[@processed_source.path].include?(line_number)
+            Diff.changed_lines[processed_source.path].include?(line_number)
         end
       end
 

--- a/lib/govuk/lint/diff.rb
+++ b/lib/govuk/lint/diff.rb
@@ -3,6 +3,8 @@ module Govuk
     module Diff
       module EnabledLines
         def enabled_line?(line_number)
+          return true unless @processed_source
+
           super(line_number) &&
             Diff.changed_lines[@processed_source.path].include?(line_number)
         end


### PR DESCRIPTION
Maybe there is a better way to do this.

Rubocop returns true when `@processed_source` is nil/false

``` ruby
def enabled_line?(line_number)
  return true unless @processed_source
  @processed_source.comment_config.cop_enabled_at_line?(self, line_number)
end
```

This PR duplicates that guard statement in the method override of `enabled_lined?` so it can continue to return safely when `@processed_source` is nil/false, and switches access to use Rubocop's attr_accessor for `@processed_source`.
