### PR TITLE
Update cops for Ruby to disable IfUnlessModifier

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -131,7 +131,7 @@ For:
 
 IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
-  Enabled: true
+  Enabled: false
   MaxLineLength: 80
 
 MethodCalledOnDoEndBlock:


### PR DESCRIPTION
Re: alphagov/smart-answers#2306

Maybe this cop should be disabled?

I've run into a couple of cases when forcing single line if/unless blocks to be re-written as one line statement with the conditional statement at the end of the line, has made it a little less readable.

When we have sequence of if/unless statements, some with multiple lines within the if statement block and some with a single line, forcing the single line statements to re-written makes it a little harder to follow the branching logic. For example:

``` ruby
if some_condition
  do_this
  and_this
end

try_this if another_condition

if last_condition
  finish_with_this
  and_also_this
end
```

In this scenario, I would prefer to keep all the branches in the same format, even though there is only one line in the block of the middle if statement, for example:

``` ruby
if some_condition
  do_this
  and_this
end

if another_condition
  try_this
end

if last_condition
  finish_with_this
  and_also_this
end
```

The second scenario, when we have a long line of code within the block of an if statement, pushing that out to the end statement, I think makes it less noticeable. For example

``` ruby
if some_condition
  do_a_really_long_method_name_or_expression_that_takes_a_lot_of_view_space
end
```

verses:

``` ruby
do_a_really_long_method_name_or_expression_that_takes_a_lot_of_view_space if some_condition
```

In the [PR for smart answers](https://github.com/alphagov/smart-answers/pull/2306) where this came up, I've added Rubocop `#enable` and `#disable` directives around a block of code to allow this, but maybe this cop can be relaxed so we don't have to litter these through our code?
