### PR TITLE
Disable default closing paren indentation.

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -15,6 +15,10 @@ CaseIndentation:
   - end
   IndentOneStep: false
 
+Style/ClosingParenthesisIndentation:
+  Description: 'Checks the indentation of hanging closing parentheses.'
+  Enabled: false
+
 ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
   Enabled: true


### PR DESCRIPTION
This contradicts our styleguide
https://github.com/alphagov/styleguides/blob/master/ruby.md#general
