### PR TITLE
Raise and/or warning only in conditionals

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -119,6 +119,7 @@ TrailingBlankLines:
 AndOr:
   Description: Use &&/|| instead of and/or.
   Enabled: true
+  EnforcedStyle: conditionals
 
 # Supports --auto-correct
 DefWithParentheses:


### PR DESCRIPTION
From our [styleguide](https://github.com/alphagov/styleguides/blob/master/ruby.md#syntax):

Always use && and || for logic. The and and or keywords should be used only for
control flow, and only in simple cases. (AndOr)

```
def some_method
  save_changes or raise "Cthulhu fhtagn"
  do_something_else
end
```

Currently `govuk-lint` does not allow this case and this PR updates it to reflect our styleguides.
We found out about this clash with the styleguide when running the checks on this line:
https://github.com/alphagov/rummager/pull/571/files?diff=unified#diff-083eeb7a1599f2e1049dd88a094efa20R59
