### PR TITLE
Never lint db/schema.rb

### DIFF
--- a/configs/rubocop/all.yml
+++ b/configs/rubocop/all.yml
@@ -4,3 +4,7 @@ inherit_from:
   - other-rails.yml
   - other-style.yml
   - other-metrics.yml
+
+AllCops:
+  Exclude:
+    - db/schema.rb


### PR DESCRIPTION
This file is autogenerated by Rails and should no be linted/autocorrected.

Having this in the default config will allow us to run `govuk-lint-ruby -a` without any special arguments and get nice results.
