### PR TITLE
Upgrade Rubocop to ~> 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Upgrade `rubocop` to `~> 0.39.0`
+
 # 0.8.1
 
 * Don't lint `db/schema.rb`.

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -291,7 +291,7 @@ HashSyntax:
   - ruby19
   - hash_rockets
 
-TrailingComma:
+TrailingCommaInLiteral:
   Description: Checks for trailing comma in parameter lists and literals.
   Enabled: false
   EnforcedStyleForMultiline: comma
@@ -299,11 +299,17 @@ TrailingComma:
   - comma
   - no_comma
 
+TrailingCommaInArguments:
+  Enabled: false
+
 # Supports --auto-correct
 WordArray:
   Description: Use %w or %W for arrays of words.
   Enabled: true
   MinSize: 0
+
+MultilineMethodCallIndentation:
+  Enabled: false
 
 ## Strings
 

--- a/configs/rubocop/other-rails.yml
+++ b/configs/rubocop/other-rails.yml
@@ -4,10 +4,6 @@ ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: false
 
-DefaultScope:
-  Description: 'Checks if the argument passed to default_scope is a block.'
-  Enabled: false
-
 Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -317,13 +317,13 @@ SingleLineMethods:
   Description: 'Avoid single-line methods.'
   Enabled: false
 
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Description: >-
     Checks that exactly one space is used between a method name
     and the first argument for method calls without parentheses.
   Enabled: false
 
-SpaceAfterControlKeyword:
+SpaceAroundKeyword:
   Description: 'Use spaces after if/elsif/unless/while/until/case/when.'
   Enabled: false
 
@@ -343,10 +343,6 @@ SpaceInsideBlockBraces:
     For blocks taking parameters, checks that the left brace has
     or doesn't have trailing space.
   Enabled: true
-
-SpaceBeforeModifierKeyword:
-  Description: 'Put a space before the modifier keyword.'
-  Enabled: false
 
 SpaceInsideHashLiteralBraces:
   Description: "Use spaces inside hash literal braces - or don't."

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "gem_publisher", "1.5.0"
   spec.add_development_dependency "rspec", "~> 3.3"
 
-  spec.add_dependency "rubocop", "~> 0.35.0"
+  spec.add_dependency "rubocop", "~> 0.39.0"
   spec.add_dependency "scss_lint", "~> 0.44.0"
 end

--- a/lib/govuk/lint/diff.rb
+++ b/lib/govuk/lint/diff.rb
@@ -40,8 +40,6 @@ module Govuk
         end
       end
 
-    private
-
       def self.changed_files
         `git diff #{commit_options} --name-only`.
           split.

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "0.8.1"
+    VERSION = "0.8.1".freeze
   end
 end


### PR DESCRIPTION
- Rename/remove deprecated parameters:

```
Error: The `Style/TrailingComma` cop no longer exists. Please use `Style/TrailingCommaInLiteral` and/or `Style/TrailingCommaInArguments` instead.
Error: The `Rails/DefaultScope` cop no longer exists.
Error: The `Style/SingleSpaceBeforeFirstArg` cop has been renamed to `Style/SpaceBeforeFirstArg.
Error: The `Style/SpaceAfterControlKeyword` cop has been removed. Please use `Style/SpaceAroundKeyword` instead.
Error: The `Style/SpaceBeforeModifierKeyword` cop has been removed. Please use `Style/SpaceAroundKeyword` instead.
```
## Why:

We're updating Rummager dependencies. [ticket](https://trello.com/c/1mXjOji6/565-upgrade-rummager-dependencies)
- I've upgraded the Ruby parser. The parser now raises a warning that is then mistakenly raised as a lint offence by the current version of Rubocop. [Issue](https://github.com/whitequark/parser/issues/283)
- Rubocop introduced a workaround to this in `0.39.0`. [commit](https://github.com/bbatsov/rubocop/commit/5e820eb5cfddf5e0f7efd2c0fa99e6b8a4c7b7e0)
