### PR TITLE
Bump gem version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.0.0
 
 * Upgrade `rubocop` to `~> 0.39.0`
 

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "0.8.1".freeze
+    VERSION = "1.0.0".freeze
   end
 end


### PR DESCRIPTION
This upgrades rubocop from 0.35.0 to 0.39.0. Some parameters have been renamed or discontinued. Upgrading to this gem version might require to update the local `rubocop.yml` accordingly.
