### PR TITLE
Ruby style - constants should be frozen

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -19,6 +19,10 @@ Style/ClosingParenthesisIndentation:
   Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: false
 
+Style/MutableConstant:
+  Description: 'Freeze mutable objects assigned to constants.'
+  Enabled: true
+
 ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
   Enabled: true


### PR DESCRIPTION
By default constants in Ruby an be reassigned and mutated. Object#freeze
can be called on "CONSTANTS" to prevent any further modification.

It's also worth noting that  Ruby 2.1 includes a memory optimisation for
frozen strings whereby the same ummutable string object is always
returned, so as well as this being good practice it may also save
memory[0]

[0] - http://josephyi.com/freeze/
