### PR TITLE
Disable Style/FrozenStringLiteralComment

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -379,3 +379,6 @@ WhileUntilModifier:
     Favor modifier while/until usage when you have a
     single-line body.
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
Style/FrozenStringLiteralComment is new in 0.39 and only works on Ruby 2.3. It mandates the use of the frozen string comment.

More info:

http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment

I'd like to disable this because I feel this the we haven't talked a lot about freezing strings at GOV.UK yet. Having to add the comment now may be a surprise to quite a few people.
