### PR TITLE
Disable `Style/ConditionalAssignment`

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -382,3 +382,6 @@ WhileUntilModifier:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false


### PR DESCRIPTION
This cop says that:

``` ruby
foo = if bar
  1
else
  2
```

is better than

``` ruby
if bar
  foo = 1
else
  foo = 2
end
```

I think on many projects we actually prefer the second style.
