### PR TITLE
Disable `Performance/TimesMap`

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -382,3 +382,6 @@ WhileUntilModifier:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Performance/TimesMap:
+  Enabled: false


### PR DESCRIPTION
This cop says that:

``` ruby
5.times.map { |x| ... }
```

should be corrected to 

``` ruby
Array.new(5) { |x| ... }
```

I think the correction is less readable and obscures intent.
