### PR TITLE
Unpin scss_lint and rake to govuk-lint can be upgraded

### DIFF
--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "gem_publisher", "1.5.0"
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop", "~> 0.39.0"
-  spec.add_dependency "scss_lint", "~> 0.44.0"
+  spec.add_dependency "scss_lint"
 end


### PR DESCRIPTION
Some apps (e.g. `collections-publisher`) use a newer version of rake.
The fact that this repo pins the version of rake makes it difficult to
upgrade `govuk-lint` without pinning rake to version `10.0`.

This change aims at removing specific versions from the gemspec file so every
app can make a decision of what version of rake/govuk-lint they need.
