### PR TITLE
Disable SCSS shorthand linting

### DIFF
--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -131,7 +131,7 @@ linters:
     convention: hyphenated_lowercase
 
   Shorthand:
-    enabled: true
+    enabled: false
     allowed_shorthands: [1, 2, 3]
 
   SingleLinePerProperty:


### PR DESCRIPTION
Warning against 4 value shorthand isn’t useful: there are valid situations for this in our projects.
