### PR TITLE
we need to be explicit in url imports

### DIFF
--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -74,8 +74,8 @@ linters:
 
   ImportPath:
     enabled: true
-    leading_underscore: false
-    filename_extension: false
+    leading_underscore: true
+    filename_extension: true
 
   Indentation:
     enabled: true


### PR DESCRIPTION
We should be more explicit when importing partials in to SASS files.

It is obviously nicer to ignore the underscores and file extensions, but in doing so we open up potential errors getting missed in the code.

There are developers of different skill levels working on Gov projects and have got juniors or those with low skill levels in SASS, it is confusing that URLS don't match up.

Furthermore when we allow imports to ignore underscore we open ourselves up to issues such as:
- developers creating SASS files intended to be partials but without the underscore and thinking its ok.
- developers removing underscores from filenames thinking they are mistakes
- developers creating files with the same name as an existing partial (without an underscore) and trying to import.
- incorrect import rules getting missed in code reviews because they appear correct.

As a general rule of thumb we should be explicit in these things to remove ambiguity and improve the quality of our code.
