### PR TITLE
Allow local file .rubocop.yml override Excludes

### DIFF
--- a/configs/rubocop/all.yml
+++ b/configs/rubocop/all.yml
@@ -4,7 +4,4 @@ inherit_from:
   - other-rails.yml
   - other-style.yml
   - other-metrics.yml
-
-AllCops:
-  Exclude:
-    - db/schema.rb
+  - other-excludes.yml

--- a/configs/rubocop/other-excludes.yml
+++ b/configs/rubocop/other-excludes.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Exclude:
+    - db/schema.rb

--- a/spec/lib/config_file_spec.rb
+++ b/spec/lib/config_file_spec.rb
@@ -18,5 +18,11 @@ RSpec.describe Govuk::Lint::ConfigFile do
       expect(file['inherit_from']).to include(local_rubocop_file)
       expect(file['inherit_from'].size > 1).to eql(true)
     end
+
+    it 'does not contain the `AllCops/Exclude` in temporary config'do
+      cli = Govuk::Lint::ConfigFile.new
+      file = YAML.load_file(cli.config_file_path)
+      expect(file['AllCops'] || {}).to_not include('Exclude')
+    end
   end
 end


### PR DESCRIPTION
## What

Currently one cannot define a `AllCops/Exclude` in the `.rubocop.yml`, because it will be overrode by `all.yml`.

You can see the [issue here](https://travis-ci.org/alphagov/paas-cf/builds/152691383), despite we define the [Exclude here](https://github.com/alphagov/paas-cf/blob/97c873fba6eda3a45cb265df171f82c2499862c1/.rubocop.yml#L1). We need to ignore files from vendored gems that are loaded in a subdirectory (`scripts/vendor/**/*`). 
## Details

Given how rubocop resolves the `inherit_from` and config files, the different files will override in order the other configs hash sub-values. Finally the root file has priority.

Because that, `AllCops/Exclude` in the main file `all.yml` will override any optional `AppCops/Exclude` from local file passed by the user.

The solution is split the `AppCops/Exclude` and add it as an additional file in the `inherit_from` list of files, so that the local file can override the value if desired.

Tests has been added to ensure that the local file is the last one added and that the root file does not include the `AllCops/Exclude` entry.

[1] https://github.com/bbatsov/rubocop/blob/49598a035cd39a75ec91466a4e1a79c7e4f0f5f9/lib/rubocop/config_loader_resolver.rb#L24
