### PR TITLE
Disable the Style/MultilineBlockLayout cop.

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -385,3 +385,6 @@ Style/FrozenStringLiteralComment:
 
 Performance/TimesMap:
   Enabled: false
+
+Style/MultilineBlockLayout:
+  Enabled: false


### PR DESCRIPTION
There's a common pattern for writing rspec `let` blocks that return a
hash as follows:

``` ruby
let(:thing) {{
  "key1" => "value,
  "key2" => "value",
}}
```

This is especially common with rspec-puppet (eg https://github.com/alphagov/govuk-puppet/search?q=let+%28%3Aparams%29&type=Code).

The [Style/MultilineBlockLayout cop](https://github.com/bbatsov/rubocop/blob/v0.39.0/config/enabled.yml#L419) prevents us from using this, so
disable it.
