### PR TITLE
Remove PlaceholderInExtend linter from SCSS

### DIFF
--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -99,9 +99,6 @@ linters:
     max_depth: 5 # ideally 3
     ignore_parent_selectors: true
 
-  PlaceholderInExtend:
-    enabled: true
-
   PropertyCount:
     enabled: false
 


### PR DESCRIPTION
This is a nice linter. It suggests the use of a placeholder selector rather
than a class selector, as it would generate less code [1]. However, since we use
Twitter Bootstrap as a baseline and Twitter Bootstrap does not support
placeholder selectors (due to issues with media queries [2]), this linter raises
errors that we cannot fix. This relates to admin apps (e.g. `content-tagger`.

By removing this linter we suppress errors we couldn't otherwise fix.

[1] https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#placeholderinextend
[2] https://github.com/twbs/bootstrap-sass/issues/721

Edit: I could disable the linter in place where needed, but I was wondering if it could be disabled globally here (assuming it doesn't impact anything else).
