### PR TITLE
Change scss-lint config to allow elements with classes

### DIFF
--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -120,7 +120,7 @@ linters:
   QualifyingElement:
     enabled: true
     allow_element_with_attribute: true # eg elements based on aria attributes
-    allow_element_with_class: false
+    allow_element_with_class: true
     allow_element_with_id: false
 
   SelectorDepth:


### PR DESCRIPTION
When I added some styling to static (in alphagov/static#849) I ran across some issues which scss-lint raised. I fixed all issues except one, because when I looked through our config I identified one specific setting I would like to change:

[QualifyingElement](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#qualifyingelement):
> Avoid qualifying elements in selectors (also known as "tag-qualifying").

... which has 3 options, one of which I propose to change:
> `allow_element_with_class`: Allow elements to qualify classes (default *false*)

What this setting means right now is that you're not able to write CSS selectors like e.g. `table.financial-data` or `p.foo`. I agree that over-specifying classes is usually not great. But it also makes sense more often than "just a few exceptions here and there" (which you could handle via inline disabling of the scss-lint config option).
One example is in the linked PR: When I'd like to style a table which inherits the styling from `table`, I'd like to specify that with a class. And that styling won't make any sense on any other element, so using the selector `table.financial-data` makes more sense to me than `.financial-data-table`.

## Discuss

I would like to use this PR to discuss and gather **pros and cons for allowing elements with classes**.
(I have intentionally not added a proper description to the commit yet as I plan to add a summary of the discussion to it.)