### PR TITLE
Disallow 3 term shorthand in Sass

### DIFF
--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -131,8 +131,8 @@ linters:
     convention: hyphenated_lowercase
 
   Shorthand:
-    enabled: false
-    allowed_shorthands: [1, 2, 3]
+    enabled: true
+    allowed_shorthands: [1, 2, 4]
 
   SingleLinePerProperty:
     enabled: true


### PR DESCRIPTION
The 3 term shorthand, eg: `padding: 5px 0 10px` is confusing.

* Re-enable the check (previously disabled in dcdd0a9)
* Allow 4 value shorthands (as per https://github.com/alphagov/govuk-lint/pull/54)

cc @robinwhittleton 