### PR TITLE
Allow BEM CSS

### DIFF
--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -128,7 +128,7 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase
+    convention: hyphenated_BEM
 
   Shorthand:
     enabled: false


### PR DESCRIPTION
This change allows [BEM-style](http://getbem.com/introduction/) syntax, which should be a superset of our previous setting (lowercase hyphenated).

Trello: https://trello.com/c/vHD20Dai/364-change-gov-uk-sass-linting-to-allow-bem-css