### PR TITLE
Upgrade Rubocop to ~> 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Upgrade `rubocop` to `~> 0.43.0`
+
 # 1.2.1
 
 * Allow local .rubocop.yml to override the `AllCops/Exclude` configuration

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -100,7 +100,7 @@ CyclomaticComplexity:
   Description: 'Avoid complex methods.'
   Enabled: false
 
-DeprecatedHashMethods:
+PreferredHashMethods:
   Description: 'Checks for use of deprecated Hash methods.'
   Enabled: false
 

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "gem_publisher", "1.5.0"
   spec.add_development_dependency "rspec", "~> 3.3"
 
-  spec.add_dependency "rubocop", "~> 0.39.0"
+  spec.add_dependency "rubocop", "~> 0.43.0"
   spec.add_dependency "scss_lint"
 end

--- a/lib/govuk/lint/cli.rb
+++ b/lib/govuk/lint/cli.rb
@@ -8,12 +8,13 @@ module Govuk
   module Lint
     class CLI < RuboCop::CLI
       def run(args = ARGV)
-        args += ["--config",
-                 ConfigFile.new.config_file_path,
-                 "--display-cop-names",
-                 "--extra-details",
-                 "--display-style-guide",
-                ]
+        args += [
+          "--config",
+          ConfigFile.new.config_file_path,
+          "--display-cop-names",
+          "--extra-details",
+          "--display-style-guide",
+        ]
 
         Diff.enable!(args) if args.include? "--diff"
 


### PR DESCRIPTION
Upgraded to version 0.43.0 in order to add the Style/DocumentationMethod cop.

https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0430-2016-09-19