### PR TITLE
Bump gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.0.0
 
 * Upgrade `rubocop` to `~> 0.43.0`
 

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "1.2.1".freeze
+    VERSION = "2.0.0".freeze
   end
 end


### PR DESCRIPTION
This upgrades rubocop from 0.39.0 to 0.43.0.
Some parameters have been renamed or discontinued.
Upgrading to this gem version might require to update the local rubocop.yml accordingly.