### PR TITLE
Disable Style/SafeNavigation cop

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -297,6 +297,12 @@ RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   Enabled: false
 
+Style/SafeNavigation:
+  Description: >-
+    This cop transforms usages of a method call safeguarded by a check for the
+    existance of the object to safe navigation (`&.`).
+  Enabled: false
+
 SelfAssignment:
   Description: 'Checks for places where self-assignment shorthand should have been used.'
   Enabled: false


### PR DESCRIPTION
govuk-lint now uses a newer version of Rubocop (PR #66) which includes the
Style/SafeNavigation cop and enables it by default.

This cop enforces the use of Ruby's safe navigation operator, `&.`

This is a relatively new Ruby feature and is not mentioned in the [Ruby style
guide](https://github.com/alphagov/styleguides/blob/master/ruby.md), so this commit disables it by default.