### PR TITLE
Protect against commas and quotes in word arrays

### DIFF
--- a/configs/rubocop/other-lint.yml
+++ b/configs/rubocop/other-lint.yml
@@ -76,6 +76,10 @@ ParenthesesAsGroupedExpression:
      parenthesis.
   Enabled: true
 
+PercentStringArray:
+  Description: Checks for unwanted commas and quotes in %w/%W literals eg %w('foo', “bar”).
+  Enabled: true
+
 RequireParentheses:
   Description: >-
      Use parentheses in the method call to avoid confusion


### PR DESCRIPTION
A comma in a word array caused a subtle bug in Publisher:
https://github.com/alphagov/publisher/pull/615

We encourage use of %w, we should protect against the risk of misuse.

Example offense that would have prevented bug:
```
Offenses:

app/services/publishing_api_workflow_bypass_publisher.rb:52:33: W: Lint/PercentStringArray: Within %w/%W, quotes and ',' are unnecessary and may be unwanted in the resulting strings. 
      .where(state: { "$nin" => %w(published, archived) })
                                ^^^^^^^^^^^^^^^^^^^^^^^
```

cc @whoojemaflip 