### PR TITLE
Use modern jenkins script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,46 +1,6 @@
 #!/usr/bin/env groovy
 
-REPOSITORY = 'govuk-lint'
-
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-
-  try {
-    stage('Checkout') {
-      checkout scm
-    }
-
-    stage('Clean') {
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-    }
-
-    stage('Bundle') {
-      echo 'Bundling'
-      sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME}")
-    }
-
-    stage('Linter') {
-      sh("bundle exec bin/govuk-lint-ruby lib bin/govuk-lint-ruby")
-      sh("bundle exec bin/govuk-lint-ruby lib bin/govuk-lint-ruby --diff")
-    }
-
-    stage('Tests') {
-      govuk.runTests('test')
-    }
-
-    if(env.BRANCH_NAME == "master") {
-      stage('Publish Gem') {
-        govuk.publishGem(REPOSITORY, env.BRANCH_NAME)
-      }
-    }
-
-  } catch (e) {
-    currentBuild.result = 'FAILED'
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject()
 }

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,3 @@
-require "gem_publisher"
-
-task :publish_gem do |t|
-  gem = GemPublisher.publish_if_updated("govuk-lint.gemspec", :rubygems)
-  puts "Published #{gem}" if gem
-end
-
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "gem_publisher", "1.5.0"
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop", "~> 0.43.0"


### PR DESCRIPTION
This uses the shared `buildProject()` script, which also releases the gem (so we don't need gem_publisher anymore).