### PR TITLE
Allow v0.49.x of rubocop and bump version to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0
+
+* Upgrade `rubocop` to `~> 0.49.0`
+
 # 2.1.0
 
 * Enable `Lint/PercentStringArray`, protect against commas and quotes in word arrays (#71)

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -9,7 +9,7 @@ BlockAlignment:
 CaseIndentation:
   Description: Indentation of when in a case/when/[else/]end.
   Enabled: true
-  IndentWhenRelativeTo: case
+  EnforcedStyle: case
   SupportedStyles:
   - case
   - end

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -299,9 +299,6 @@ TrailingCommaInLiteral:
   Description: Checks for trailing comma in parameter lists and literals.
   Enabled: false
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
-  - comma
-  - no_comma
 
 TrailingCommaInArguments:
   Enabled: false

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -146,7 +146,7 @@ MethodCalledOnDoEndBlock:
   Description: Avoid chaining a method call on a do...end block.
   Enabled: true
 
-MethodCallParentheses:
+MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   Enabled: true
 

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.3"
 
-  spec.add_dependency "rubocop", "~> 0.43.0"
+  spec.add_dependency "rubocop", "~> 0.49.0"
   spec.add_dependency "scss_lint"
 end

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "2.1.0".freeze
+    VERSION = "3.0.0".freeze
   end
 end


### PR DESCRIPTION
* Relaxes the gem specification constraint on `rubocop` from "\~> 0.43.0" to "\~> 0.49.0". The latest version of `rubocop` is v0.49.1.
* Fixes some errors & warnings by making changes to `configs/rubocop/gds-ruby-styleguide.yml`.
* Bumps version of this gem from v2.1.0 to v3.0.0 - similar changes in the past seem to have been major version increments.
* Update `CHANGELOG.md`

The changes in `rubocop` are mostly bug fixes or new features, so I don't think there's too much risk in relaxing the constraint to allow the latest version. And in any case each project is in control of which version of `govuk-lint` being used and thence the version `rubocop`.

My specific motivation is the relaxation of the "Style/VariableNumber" rule in [this commit][1] which I believe was first released in v0.44.0. The strictness of this rule in v0.43.0 is causing me a problem in `asset-manager` app where I want to use a local variable named `aws_s3_bucket_name`.

[1]: https://github.com/bbatsov/rubocop/commit/833aad6ccb35a16c6196830e936f4ef34384590b
