### PR TITLE
Fix namespace for ClosingParenthesisIndentation config and bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+* Fix namespace for `ClosingParenthesisIndentation` config
+
 # 3.0.0
 
 * Upgrade `rubocop` to `~> 0.49.0`

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -15,7 +15,7 @@ CaseIndentation:
   - end
   IndentOneStep: false
 
-Style/ClosingParenthesisIndentation:
+Layout/ClosingParenthesisIndentation:
   Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: false
 

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "3.0.0".freeze
+    VERSION = "3.1.0".freeze
   end
 end


### PR DESCRIPTION
I saw the following warning when running `govuk-lint-ruby` after the upgrade to rubocop v0.49.1 in v3.0.0 of govuk-lint:

    [...]/govuk-lint-3.0.0/configs/rubocop/gds-ruby-styleguide.yml: Style/ClosingParenthesisIndentation has the wrong namespace - should be Layout

This fixes that warning.