### PR TITLE
Allow hyphenated BEM in CSS

### DIFF
--- a/configs/scss_lint/gds-sass-styleguide.yml
+++ b/configs/scss_lint/gds-sass-styleguide.yml
@@ -128,7 +128,7 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase
+    convention: hyphenated_BEM
 
   Shorthand:
     enabled: false


### PR DESCRIPTION
The GOV.UK Frontend alpha uses a BEM convention:
https://github.com/alphagov/govuk-frontend/blob/master/docs/coding-standards/css.md

This convention encourages isolation within components.

GOV.UK Publishing Frontend (www.gov.uk) are writing components that conform to this convention. Components should be easily movable/promotable to GOV.UK Frontend when appropriate.

* An extension of our original rules, hyphenated classes are still ok
* Allows underscores in BEM classes only
* Specifics of what is/is not allowed here: https://github.com/brigade/scss-lint/blob/d8645c43c85bae837e283b498c39af63575c8a82/spec/scss_lint/linter/selector_format_spec.rb#L539-L630

| Selector | Allowed |
|--|--|
| `.block` | ✅  |
| `.b-block` | ✅  |
| `.b-block-name` | ✅  |
| `.b-block--modifier` | ✅  |
| `.block_modifier` | ❌  |
| `.block--modifier-value` | ✅ |
| `.b-block-name--modifier-name-here-value-name-here` | ✅ |
| `.b-block__element` | ✅ |
| `.block--modifier-value__element` | ✅  |
| `.block__element--modifier-value`| ✅  |
| `.block__element--modifier`| ✅  |
| `.a_block__element--modifier`| ❌  |
| `.block__an_element--modifier`| ❌  |
| `.block__element--a_modifier`| ❌  |

This is the same as @alecgibson’s PR which had a lot of debate: https://github.com/alphagov/govuk-lint/pull/65

In February we decided _not_ to do this here, most of those concerns have since been addressed:
https://github.com/alphagov/govuk-lint/pull/65#issuecomment-278436300


