### PR TITLE
Version 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.0
+
+* Relax class naming rules for Sass to allow hyphenated BEM classes (#79)
+
 # 3.1.0
 
 * Fix namespace for `ClosingParenthesisIndentation` config

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "3.1.0".freeze
+    VERSION = "3.2.0".freeze
   end
 end


### PR DESCRIPTION
* Relax class naming rules for Sass to allow hyphenated BEM classes (#79)