### PR TITLE
Don't complain about block length in tests

### DIFF
--- a/configs/rubocop/other-excludes.yml
+++ b/configs/rubocop/other-excludes.yml
@@ -1,3 +1,9 @@
 AllCops:
   Exclude:
     - db/schema.rb
+
+Metrics/BlockLength:
+  Enabled: true
+  Exclude:
+    - test/**/*
+    - spec/**/*


### PR DESCRIPTION
Many test frameworks use blocks for the entire test case in a file as well as for individual tests within the file.  It's not unusual for a test case to be several lines longer than the upper limit of the BlockLength cop, and there's very little we can do to avoid that so there's no point running this cop on our tests.

See: https://github.com/alphagov/support/pull/319/commits/4d5bcbc102fc2da80ccd7dc89926917dd42f6492 and https://github.com/alphagov/specialist-publisher/pull/1053/commits/1991ab99f1bb85869a1bcee9efddd693e09d9c77 where I've done this in `.rubocop.yml` for a couple of projects.  There's bound to be more so this feels like something we should do in one place.