### PR TITLE
Make RSpec-related cops available from rubocop-rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Useful options:
 
 See more options in the [rubocop][rubocop] README.
 
+#### RSpec
+
+You can enable RSpec cops by adding the following line to the `.rubocop.yml` file in your project:
+
+```
+require: rubocop-rspec
+```
+
 ### Sass
 
 Linter: [scss-lint](https://github.com/brigade/scss-lint)

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop", "~> 0.49.0"
+  spec.add_dependency "rubocop-rspec"
   spec.add_dependency "scss_lint"
 end

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop", "~> 0.49.0"
-  spec.add_dependency "rubocop-rspec"
+  spec.add_dependency "rubocop-rspec", "~> 1.16.0"
   spec.add_dependency "scss_lint"
 end


### PR DESCRIPTION
Since not all projects use RSpec, I've only added the gem dependency. To actually enable the cops, you need to add a line to your `.rubocop.yml` file. I've explained this in an addition to the README.

I had hoped this would solve the `Metrics/BlockLength` problem mentioned in #80, but it turns out that it doesn't. Thus I have approved #82.

However, I still think that making `rubocop-rspec` available is worthwhile - I ran it against Asset Manager and it came up with a bunch of sensible suggestions and a number of them are auto-correctable.
