### PR TITLE
Bump rubocop to 0.51.0

### DIFF
--- a/configs/rubocop/other-lint.yml
+++ b/configs/rubocop/other-lint.yml
@@ -50,12 +50,6 @@ HandleExceptions:
   Description: "Don't suppress exception."
   Enabled: true
 
-InvalidCharacterLiteral:
-  Description: >-
-     Checks for invalid character literals with a non-escaped
-     whitespace character.
-  Enabled: true
-
 LiteralInCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -245,10 +245,6 @@ NumericLiterals:
     readability.
   Enabled: false
 
-OpMethod:
-  Description: 'When defining binary operators, name the argument other.'
-  Enabled: false
-
 ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   Enabled: false

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.3"
 
-  spec.add_dependency "rubocop", "~> 0.49.0"
+  spec.add_dependency "rubocop", "~> 0.51.0"
   spec.add_dependency "rubocop-rspec", "~> 1.16.0"
   spec.add_dependency "scss_lint"
 end


### PR DESCRIPTION
A security vulnerability has been detected in Rubocop versions 0.48.1 and earlier (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418).
This bumps Rubocop to the most recent version.