### PR TITLE
Metrics/BlockLength for specs in sub-dirs

### DIFF
--- a/configs/rubocop/other-excludes.yml
+++ b/configs/rubocop/other-excludes.yml
@@ -6,4 +6,4 @@ Metrics/BlockLength:
   Enabled: true
   Exclude:
     - test/**/*
-    - spec/**/*
+    - "**/spec/**/*"


### PR DESCRIPTION
On GOV.UK PaaS we have a monorepo with multiple sub-directories that contain
their own `spec` directories for tests. Change the exclude pattern to allow
for this, which will also satisfy the original behaviour of a single `spec`
directory in the repository root. The string has to be quoted otherwise the
YAML parser will complain about the asterisks.