### PR TITLE
Rename LiteralInCondition cop to LiteralAsCondition

### DIFF
--- a/configs/rubocop/other-lint.yml
+++ b/configs/rubocop/other-lint.yml
@@ -50,7 +50,7 @@ HandleExceptions:
   Description: "Don't suppress exception."
   Enabled: true
 
-LiteralInCondition:
+LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true
 


### PR DESCRIPTION
The `LiteralInCondition` cop has been renamed to `LiteralAsCondition` in
Rubocop version 0.51.0. Renaming this in configs/rubocop/other-lint.yml
prevents an unrecognized cop warning.

[Rubocop changelog](https://github.com/bbatsov/rubocop/blob/bed2a62e473fe5b6b26b3a572fb5432a7dc56b93/CHANGELOG.md#changes-1)