### PR TITLE
Fix deprecation warnings

### DIFF
--- a/configs/rubocop/other-lint.yml
+++ b/configs/rubocop/other-lint.yml
@@ -50,7 +50,7 @@ HandleExceptions:
   Description: "Don't suppress exception."
   Enabled: true
 
-LiteralInCondition:
+LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true
 

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop", "~> 0.51.0"
-  spec.add_dependency "rubocop-rspec", "~> 1.16.0"
+  spec.add_dependency "rubocop-rspec", "~> 1.19.0"
   spec.add_dependency "scss_lint"
 end


### PR DESCRIPTION
[The Lint/LiteralInCondition cop was renamed to Lint/LiteralAsCondition in Rubocop v0.50.0][1] (more specifically [this PR][2]) and so we need to update the configuration key to avoid the following deprecation warning:

    Warning: unrecognized cop LiteralInCondition found in ...

I'm aware that [this existing PR][5] already includes the above fix, but it appears to have been submitted from a fork of the repo and its not obvious that the CI server is going to build it.

Upgrade `rubocop-rspec` dependency to at least v1.19.0 to fix deprecation warnings. I was seeing multiple occurrences of the following deprecation warning:

    Warning: The usage of positional location, message, and severity
    parameters to Cop#add_offense is deprecated. Please use keyword
    arguments instead.

    The positional arguments version of Cop#add_offense will be removed
    in RuboCop 0.52

[This appears to have been fixed in `rubocop-rspec` v1.19.0][3] (more specifically in [this PR][4]). This upgrade of rubocop-rspec doesn't appear to contain any problematic changes - in fact it's mainly bug fixes.

[1]: https://github.com/bbatsov/rubocop/blob/v0.51.0/CHANGELOG.md#changes
[2]: https://github.com/bbatsov/rubocop/pull/4864
[3]: https://github.com/backus/rubocop-rspec/blob/master/CHANGELOG.md#1190-2017-10-18
[4]: https://github.com/backus/rubocop-rspec/pull/484
[5]: https://github.com/alphagov/govuk-lint/pull/88