### PR TITLE
Bump version to v3.4.0 & update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.4.0
+
+* Metrics/BlockLength for specs in sub-dirs (#87)
+* Bump rubocop-rspec to v1.19.0 to fix deprecation warnings (#89)
+* Fix config for Lint/LiteralInCondition cop which was renamed in Rubocop v0.50.0 (#89)
+
 # 3.3.1
 
 * Bump Rubocop to version 0.51.0 to fix a security vulnerability.

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "3.3.1".freeze
+    VERSION = "3.4.0".freeze
   end
 end


### PR DESCRIPTION
I've bumped the minor version, because #89 bumped the version of `rubocop-rspec` from v1.16.0 to v1.19.0.