### PR TITLE
Disable Rails/SkipsModelValidations cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Disabled Rails/SkipsModelValidations (#92)
+
 # 3.4.0
 
 * Metrics/BlockLength for specs in sub-dirs (#87)

--- a/configs/rubocop/other-rails.yml
+++ b/configs/rubocop/other-rails.yml
@@ -27,3 +27,7 @@ ScopeArgs:
 Validation:
   Description: 'Use sexy validations.'
   Enabled: false
+
+SkipsModelValidations:
+  Description: 'Avoid methods that skip model validations.'
+  Enabled: false


### PR DESCRIPTION
This cop errors if we use any of the methods listed in http://guides.rubyonrails.org/active_record_validations.html#skipping-validations but there are lots of good reasons to do so for performance reasons, or object lifecycle reasons (particularly in migrations, but elsewhere too) so we turn this cop off.