### PR TITLE
Don't check for duplicated gem definitions

### DIFF
--- a/configs/rubocop/other-excludes.yml
+++ b/configs/rubocop/other-excludes.yml
@@ -7,3 +7,6 @@ Metrics/BlockLength:
   Exclude:
     - test/**/*
     - "**/spec/**/*"
+
+Bundler/DuplicatedGem:
+  Enabled: false


### PR DESCRIPTION
A common pattern in our Gemfiles is to declare a gem differently if we're in a dev mode or not. Rubocop sees this as a duplicate declaration. Example:

```ruby
if ENV['API_DEV']
  gem 'gds-api-adapters', path: '../gds-api-adapters'
else
  gem 'gds-api-adapters', "~> 50.8.0"
end
```

This is valid, so we should disable this cop.