### PR TITLE
Exclude rake task namespace blocks from block length cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Excluded `namespace` blocks in rake tasks from Metrics/BlockLength
+
 # 3.6.0
 
 * Disabled Bundler/DuplicatedGem (#93)

--- a/configs/rubocop/other-excludes.yml
+++ b/configs/rubocop/other-excludes.yml
@@ -7,6 +7,7 @@ Metrics/BlockLength:
   Exclude:
     - test/**/*
     - "**/spec/**/*"
+  ExcludedMethods: ["namespace"]
 
 Bundler/DuplicatedGem:
   Enabled: false


### PR DESCRIPTION
This commit excludes the `namespace` blocks used in rake tasks from being picked up by the block length cop. Rubocop sees the whole namespace as one block by default rather than looking task-by-task.