### PR TITLE
Move rubocop cli options to config files

### DIFF
--- a/configs/rubocop/all.yml
+++ b/configs/rubocop/all.yml
@@ -1,3 +1,16 @@
+AllCops:
+  DisplayCopNames: 
+    Description: 'Display cop names in offense messages'
+    Enabled: true
+
+  ExtraDetails:
+    Description: 'Display extra details in offense messages.'
+    Enabled: true
+
+  DisplayStyleGuide:
+    Description: 'Display style guide URLs in offense messages.'
+    Enabled: true
+
 inherit_from:
   - gds-ruby-styleguide.yml
   - other-lint.yml

--- a/lib/govuk/lint/cli.rb
+++ b/lib/govuk/lint/cli.rb
@@ -11,9 +11,6 @@ module Govuk
         args += [
           "--config",
           ConfigFile.new.config_file_path,
-          "--display-cop-names",
-          "--extra-details",
-          "--display-style-guide",
         ]
 
         Diff.enable!(args) if args.include? "--diff"


### PR DESCRIPTION
Moving the CLI arguments to the config file to standardize where options are specified. Having options in the config files reduces the dependency on the `govuk-lint-ruby` CLI and allows config to be included directly into rubocop.