### PR TITLE
[WIP] Enforce compact style naming of class and module children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Enforce a compact style when naming class and module children.
+
 # 3.11.0
 
 * Bump Rubocop to version 0.64 to fix Ruby 2.6.1 issue

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -221,6 +221,11 @@ ClassAndModuleCamelCase:
   Description: Use CamelCase for classes and modules.
   Enabled: true
 
+ClassAndModuleChildren:
+  Description: Use the compact style for naming child classes and modules.
+  EnforcedStyle: compact
+  Enabled: true
+
 # Supports --auto-correct
 ClassMethods:
   Description: Use self when defining module/class methods.

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -70,10 +70,6 @@ CharacterLiteral:
   Description: 'Checks for uses of character literals.'
   Enabled: false
 
-ClassAndModuleChildren:
-  Description: 'Checks style of children classes and modules.'
-  Enabled: false
-
 ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
   Enabled: false


### PR DESCRIPTION
This came up in a discussion we had on Platform Health during review of a PR (https://github.com/alphagov/local-links-manager/pull/421#discussion_r2776071940).

I prefer this style of naming classes as I think it looks cleaner and avoids unnecessary indentation and module lines at the top and bottom of the file.

The downside to enforcing this is that classes defined in this way can't be loaded until the parent module has already been defined. In practice, with Rails autoloading, this means that each module would need its own file `module.rb` containing just `module ModuleName; end`.

There are both styles currently present in the GOV.UK code base:
- https://github.com/alphagov/local-links-manager/blob/be4ad1f3bc0dee0d73f50c0819c89cb0af8c0584/lib/local-links-manager/import/links.rb#L3-L5
- https://github.com/alphagov/publishing-api/blob/fbd0e07dc3aaec156b8361d5e157ec1775ff6550/lib/link_expansion/link_reference.rb#L1

We should decide on a style and enforce it using govuk-lint. Personally, I prefer the compact style but if the majority would prefer the nested style, we can enforce that instead.