### PR TITLE
Rename IndentArray to IndentFirstArrayElement

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -168,7 +168,7 @@ IfWithSemicolon:
   Description: 'Never use if x; .... Use the ternary operator instead.'
   Enabled: false
 
-IndentArray:
+IndentFirstArrayElement:
   Description: >-
     Checks the indentation of the first element in an array
     literal.


### PR DESCRIPTION
This maintains compatability with the latest rubocop version, see: https://github.com/rubocop-hq/rubocop/commit/184c2a1e92caa6914fe75a0bcc484c64ab834594