### PR TITLE
Remove performance cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Remove redundant cop config for Performance/TimesMap
+
 # 3.11.1
 
 * Fix renamed cops IndentArray and IndentHash.

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -384,6 +384,3 @@ WhileUntilModifier:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
-
-Performance/TimesMap:
-  Enabled: false


### PR DESCRIPTION
These cops are no longer available in core rubocop (we're getting a warning about this). 

We seem to have [lost a fair few cops](https://github.com/rubocop-hq/rubocop/issues/5977) in taking this upgrade, but looking at the comments in the issue vvv, perhaps we should avoid platform-specific linting anyway?

https://github.com/rubocop-hq/rubocop/issues/5977