### PR TITLE
Fix GC race condition for temp config file

### DIFF
--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.3"
 

--- a/lib/govuk/lint/cli.rb
+++ b/lib/govuk/lint/cli.rb
@@ -8,9 +8,11 @@ module Govuk
   module Lint
     class CLI < RuboCop::CLI
       def run(args = ARGV)
+        config = ConfigFile.new
+
         args += [
           "--config",
-          ConfigFile.new.config_file_path,
+          config.config_file_path,
         ]
 
         Diff.enable!(args) if args.include? "--diff"

--- a/lib/govuk/lint/config_file.rb
+++ b/lib/govuk/lint/config_file.rb
@@ -9,10 +9,7 @@ module Govuk
 
       def config_file_path
         return BASE_CONFIG_FILE unless File.exist?(local_config_file_path)
-
-        config = merged_global_and_local_configs
-        file = create_tempfile_for_configs(config)
-        file.path
+        tempfile_for_configs.path
       end
 
     private
@@ -38,11 +35,13 @@ module Govuk
         @local_config_file_path ||= File.join(Dir.pwd, ".rubocop.yml")
       end
 
-      def create_tempfile_for_configs(config)
-        file = Tempfile.new('tmp-rubocop-all.yml')
-        file.write(config.to_yaml)
-        file.close
-        file
+      def tempfile_for_configs
+        @tempfile_for_configs ||= begin
+                                   file = Tempfile.new('tmp-rubocop-all.yml')
+                                   file.write(merged_global_and_local_configs.to_yaml)
+                                   file.close
+                                   file
+                                 end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/x3ESI6Il/977-update-govuk-lint-to-fix-a-race-condition-bug-with-its-config

Previously we merged a bunch of YML files into a single, temporary
config file, using the ConfigFile class, which did not retain any
reference to the instance of Tempfile it created. Depending on when
Ruby's Garbage Collector runs, the dangling Tempfile instance could
have been deleted before it could be read by the RuboCop CLI itself.

This modifies the ConfigFile class and the way it's called to ensure
a reference to the Tempfile instance is maintained until the RuboCop
CLI has finished running, at which point it can be safely GC'd.