### PR TITLE
Add dependency on new rubocop-rails gem

### DIFF
--- a/configs/rubocop/all.yml
+++ b/configs/rubocop/all.yml
@@ -1,5 +1,5 @@
 AllCops:
-  DisplayCopNames: 
+  DisplayCopNames:
     Description: 'Display cop names in offense messages'
     Enabled: true
 
@@ -10,6 +10,8 @@ AllCops:
   DisplayStyleGuide:
     Description: 'Display style guide URLs in offense messages.'
     Enabled: true
+
+require: rubocop-rails
 
 inherit_from:
   - gds-ruby-styleguide.yml

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.3"
 
+  spec.add_dependency "rubocop-rails", "~> 2"
   spec.add_dependency "rubocop", "~> 0.64"
   spec.add_dependency "rubocop-rspec", "~> 1.28"
   spec.add_dependency "scss_lint"


### PR DESCRIPTION
Previously Rails cops were provided as part of the 'rubocop' gem. This
adds a dependency on 'rubocop-rails', which is the new provider for of
these cops since v0.72.

v0.72 is only 2 hours old! So unlucky...

https://github.com/rubocop-hq/rubocop/releases/tag/v0.72.0