### PR TITLE
Bump version to 3.11.4 and rubocop to 0.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.11.4
+
+* Continue to support Rails cops using rubocop-rails
+
 # 3.11.3
 
 * Fix race condition when generating temp config file

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop-rails", "~> 2"
-  spec.add_dependency "rubocop", "~> 0.64"
+  spec.add_dependency "rubocop", "~> 0.72"
   spec.add_dependency "rubocop-rspec", "~> 1.28"
   spec.add_dependency "scss_lint"
 end

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "3.11.3".freeze
+    VERSION = "3.11.4".freeze
   end
 end


### PR DESCRIPTION
https://trello.com/c/x3ESI6Il/977-update-govuk-lint-to-fix-a-race-condition-bug-with-its-config

This ensures we don't accidentally run conflicting sets of Cops for
Rails if one of our repos insists on using an older version of rubocop.