### PR TITLE
Disable rails linting by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Re-instate disabling of Rails linting by default
+
 # 3.11.4
 
 * Continue to support Rails cops using rubocop-rails

--- a/configs/rubocop/all.yml
+++ b/configs/rubocop/all.yml
@@ -13,6 +13,9 @@ AllCops:
 
 require: rubocop-rails
 
+Rails:
+  Enabled: false
+
 inherit_from:
   - gds-ruby-styleguide.yml
   - other-lint.yml


### PR DESCRIPTION
Rails linting has been turned on by default by
https://github.com/alphagov/govuk-lint/pull/119. This seems to be an
unintended side effect so this commit re-instates the previous
behaviour.