### PR TITLE
Move Rails default disabling to inherited file

### DIFF
--- a/configs/rubocop/all.yml
+++ b/configs/rubocop/all.yml
@@ -13,9 +13,6 @@ AllCops:
 
 require: rubocop-rails
 
-Rails:
-  Enabled: false
-
 inherit_from:
   - gds-ruby-styleguide.yml
   - other-lint.yml

--- a/configs/rubocop/other-rails.yml
+++ b/configs/rubocop/other-rails.yml
@@ -1,5 +1,10 @@
 ##################### Rails ##################################
 
+# By default Rails is switched off so this can be used by non-Rails apps,
+# this can be enabled in a local .rubocop.yml file
+Rails:
+  Enabled: false
+
 ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: false


### PR DESCRIPTION
This fixes an issue where Rails linting could not be switched on by a local .rubocop.yml files. This gem employs a slightly weird system where a [global rubocop config is used as the default and the local file is set as something that this global file inherits from](https://github.com/alphagov/govuk-lint/blob/7016c9b776f3a40018ed4cbf1b1f4e82d94756da/lib/govuk/lint/config_file.rb#L17-L22). This means the global file has a higher precedence than local config files.

I had a spin at changing this around so that files are only inherited from
the local config: https://github.com/alphagov/govuk-lint/commit/66ac6d378e2147bf468358c504ba29e2956fdf21. However I was a bit concerned this could introduce some BC-breaks for any apps that rely on this quirky behaviour.