### PR TITLE
Release 3.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 3.11.5
 
 * Re-instate disabling of Rails linting by default
 

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "3.11.4".freeze
+    VERSION = "3.11.5".freeze
   end
 end


### PR DESCRIPTION
* Re-instate disabling of Rails linting by default https://github.com/alphagov/govuk-lint/pull/121 https://github.com/alphagov/govuk-lint/pull/122