### PR TITLE
Revert "Don't enforce double-quotes for strings."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Revert "Don't enforce double-quotes for strings."
+
 # 3.11.5
 
 * Re-instate disabling of Rails linting by default

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -333,7 +333,7 @@ StringConversionInInterpolation:
 # Supports --auto-correct
 StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
-  Enabled: false
+  Enabled: true
   EnforcedStyle: double_quotes
   SupportedStyles:
   - single_quotes


### PR DESCRIPTION
This reverts commit 67e3ea748c55015818e310e6cc8d9ac6a9b148c8. Based on discussions in other repos [[1]](https://github.com/alphagov/finder-frontend/pull/1545)[[2]](https://github.com/alphagov/finder-frontend/pull/1545) and what seems to be [general agreement in the community](https://github.com/rubocop-hq/rubocop/issues/5306), I think we should reenable this and eliminate the mass inconsistency that's crept into a lot of repos since 2015. It's one of those little pain points that keeps coming up. In contrast to [the original PR](https://github.com/alphagov/govuk-lint/pull/8), I think disabling the cop has actually made it harder to be consistent.

To quote @kevindew:

> Having no consistency, or changing consistency from file-to-file, is annoying, confusing and adds an extra decision you have to make before writing any code in a project.

The good news is that it's very easy to automatically fix this across an entire repo, which I'm aware is one of the consequences of merging this PR, and which I'm happy to help with.