### PR TITLE
Enforce consistency with commas in lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Re-enable Cop to enforce trailing commas
 * Revert "Don't enforce double-quotes for strings."
 
 # 3.11.5

--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -304,15 +304,16 @@ HashSyntax:
   - hash_rockets
 
 TrailingCommaInArrayLiteral:
-  Enabled: false
+  Enabled: true
   EnforcedStyleForMultiline: comma
 
 TrailingCommaInHashLiteral:
-  Enabled: false
+  Enabled: true
   EnforcedStyleForMultiline: comma
 
 TrailingCommaInArguments:
-  Enabled: false
+  Enabled: true
+  EnforcedStyleForMultiline: comma
 
 # Supports --auto-correct
 WordArray:


### PR DESCRIPTION
This was originally disabled without much explanation. In fact, the
suggested issue doesn't actually appear to be a bug i.e. the Cop was
disabled in error. We should re-enable the Cop (now split into three
separate Cops) in order to reduce the inconsistency that has since
spread across apps on GOV.UK. Having the flexibility to make this
decision is unnecessary and just takes up more development time.

Original PR: https://github.com/alphagov/styleguides/pull/50