### PR TITLE
Prefix all cop names with their category

### DIFF
--- a/configs/rubocop/gds-ruby-styleguide.yml
+++ b/configs/rubocop/gds-ruby-styleguide.yml
@@ -2,11 +2,11 @@
 ## General
 ############
 
-BlockAlignment:
+Layout/BlockAlignment:
   Description: 'Align block ends correctly.'
   Enabled: true
 
-CaseIndentation:
+Layout/CaseIndentation:
   Description: Indentation of when in a case/when/[else/]end.
   Enabled: true
   EnforcedStyle: case
@@ -23,50 +23,50 @@ Style/MutableConstant:
   Description: 'Freeze mutable objects assigned to constants.'
   Enabled: true
 
-ElseLayout:
+Lint/ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
   Enabled: true
 
 # Supports --auto-correct
-EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Description: Use empty lines between defs.
   Enabled: true
   AllowAdjacentOneLineDefs: false
 
-EmptyLines:
+Layout/EmptyLines:
   Description: "Don't use several empty lines in a row."
   Enabled: true
 
-EndAlignment:
+Layout/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
 
-EndOfLine:
+Layout/EndOfLine:
   Description: 'Use Unix-style line endings.'
   Enabled: true
 
 # Supports --auto-correct
-IndentationWidth:
+Layout/IndentationWidth:
   Description: Use 2 spaces for indentation.
   Enabled: true
 
 # Supports --auto-correct
-IndentationConsistency:
+Layout/IndentationConsistency:
   Description: Keep indentation straight.
   Enabled: true
 
-LineLength:
+Metrics/LineLength:
   Description: Limit lines to 80 characters.
   Enabled: false
   Max: 80
 
-# Supports --auto-correct
-SpaceAroundOperators:
+ # Supports --auto-correct
+Layout/SpaceAroundOperators:
   Description: Use spaces around operators.
   Enabled: true
 
 # Supports --auto-correct
-SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Description: Checks that the left block brace has or doesn't have space before it.
   Enabled: true
   EnforcedStyle: space
@@ -75,46 +75,46 @@ SpaceBeforeBlockBraces:
   - no_space
 
 # Supports --auto-correct
-SpaceAfterSemicolon:
+Layout/SpaceAfterSemicolon:
   Description: Use spaces after semicolons.
   Enabled: true
 
 # Supports --auto-correct
-SpaceAfterColon:
+Layout/SpaceAfterColon:
   Description: Use spaces after colons.
   Enabled: true
 
 # Supports --auto-correct
-SpaceAfterComma:
+Layout/SpaceAfterComma:
   Description: Use spaces after commas.
   Enabled: true
 
 # Supports --auto-correct
-SpaceInsideReferenceBrackets:
+Layout/SpaceInsideReferenceBrackets:
   Description: No spaces after array[ or before ].
   Enabled: true
 
 # Supports --auto-correct
-SpaceInsideArrayLiteralBrackets:
+Layout/SpaceInsideArrayLiteralBrackets:
   Description: No spaces after array = [ or before ].
   Enabled: true
 
 # Supports --auto-correct
-SpaceInsideParens:
+Layout/SpaceInsideParens:
   Description: No spaces after ( or before ).
   Enabled: true
 
-Tab:
+Layout/Tab:
   Description: No hard tabs.
   Enabled: true
 
 # Supports --auto-correct
-TrailingWhitespace:
+Layout/TrailingWhitespace:
   Description: Avoid trailing whitespace.
   Enabled: true
 
 # Supports --auto-correct
-TrailingBlankLines:
+Layout/TrailingBlankLines:
   Description: Checks trailing blank lines and final newline.
   Enabled: true
   EnforcedStyle: final_newline
@@ -125,16 +125,16 @@ TrailingBlankLines:
 ## Syntax
 
 # Supports --auto-correct
-AndOr:
+Style/AndOr:
   Description: Use &&/|| instead of and/or.
   Enabled: true
 
 # Supports --auto-correct
-DefWithParentheses:
+Style/DefWithParentheses:
   Description: Use def with parentheses when there are arguments.
   Enabled: true
 
-For:
+Style/For:
   Description: Checks use of for or each in multiline loops.
   Enabled: true
   EnforcedStyle: each
@@ -142,62 +142,58 @@ For:
   - for
   - each
 
-IfUnlessModifier:
+Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   Enabled: false
 
-Metrics:
-  LineLength:
-    Max: 80
-
-MethodCalledOnDoEndBlock:
+Style/MethodCalledOnDoEndBlock:
   Description: Avoid chaining a method call on a do...end block.
   Enabled: true
 
-MethodCallWithoutArgsParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   Enabled: true
 
-MultilineBlockChain:
+Style/MultilineBlockChain:
   Description: Avoid multi-line chains of blocks.
   Enabled: true
 
-MultilineIfThen:
+Style/MultilineIfThen:
   Description: Never use then for multi-line if/unless.
   Enabled: true
 
-MultilineTernaryOperator:
+Style/MultilineTernaryOperator:
   Description: 'Avoid multi-line ?: (the ternary operator); use if/unless instead.'
   Enabled: true
 
-NestedTernaryOperator:
+Style/NestedTernaryOperator:
   Description: Use one expression per branch in a ternary operator.
   Enabled: true
 
-OneLineConditional:
+Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   Enabled: true
 
 # Supports --auto-correct
-ParenthesesAroundCondition:
+Style/ParenthesesAroundCondition:
   Description: Don't use parentheses around the condition of an if/unless/while.
   Enabled: true
   AllowSafeAssignment: true
 
 # Supports --auto-correct
-RedundantReturn:
+Style/RedundantReturn:
   Description: Don't use return where it's not required.
   Enabled: true
   AllowMultipleReturnValues: false
 
 # Supports --auto-correct
-SpaceAfterMethodName:
+Layout/SpaceAfterMethodName:
   Description: Never put a space between a method name and the opening parenthesis in
     a method definition.
   Enabled: true
 
 # Supports --auto-correct
-SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   Description: Checks that the equals signs in parameter default assignments have or
     don't have surrounding space depending on configuration.
   Enabled: true
@@ -206,35 +202,35 @@ SpaceAroundEqualsInParameterDefault:
   - space
   - no_space
 
-UnlessElse:
+Style/UnlessElse:
   Description: Never use unless with else. Rewrite these with the positive case first.
   Enabled: true
 
 # Supports --auto-correct
-UnusedBlockArgument:
+Lint/UnusedBlockArgument:
   Description: Checks for unused block arguments.
   Enabled: true
 
 ## Naming
 
-ClassAndModuleCamelCase:
+Naming/ClassAndModuleCamelCase:
   Description: Use CamelCase for classes and modules.
   Enabled: true
 
 # Supports --auto-correct
-ClassMethods:
+Style/ClassMethods:
   Description: Use self when defining module/class methods.
   Enabled: true
 
-ClassVars:
+Style/ClassVars:
   Description: Avoid the use of class variables.
   Enabled: true
 
-ConstantName:
+Naming/ConstantName:
   Description: Constants should use SCREAMING_SNAKE_CASE.
   Enabled: true
 
-MethodName:
+Naming/MethodName:
   Description: Use the configured style when naming methods.
   Enabled: true
   EnforcedStyle: snake_case
@@ -243,7 +239,7 @@ MethodName:
   - camelCase
 
 # Supports --auto-correct
-TrivialAccessors:
+Style/TrivialAccessors:
   Description: Prefer attr_* methods to trivial readers/writers.
   Enabled: true
   ExactNameMatch: true
@@ -268,7 +264,7 @@ TrivialAccessors:
   - to_s
   - to_sym
 
-VariableName:
+Naming/VariableName:
   Description: Use the configured style when naming variables.
   Enabled: true
   EnforcedStyle: snake_case
@@ -279,19 +275,19 @@ VariableName:
 ## Exceptions
 
 # Supports --auto-correct
-RescueException:
+Lint/RescueException:
   Description: Avoid rescuing the Exception class.
   Enabled: true
 
 ## Collections
 
 # Supports --auto-correct
-AlignArray:
+Layout/AlignArray:
   Description: Align the elements of an array literal if they span more than one line.
   Enabled: true
 
 # Supports --auto-correct
-HashSyntax:
+Style/HashSyntax:
   Description: 'Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax { :a => 1,
     :b => 2 }.'
   Enabled: true
@@ -303,36 +299,36 @@ HashSyntax:
   - ruby19
   - hash_rockets
 
-TrailingCommaInArrayLiteral:
+Style/TrailingCommaInArrayLiteral:
   Enabled: true
   EnforcedStyleForMultiline: comma
 
-TrailingCommaInHashLiteral:
+Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: comma
 
-TrailingCommaInArguments:
+Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: comma
 
 # Supports --auto-correct
-WordArray:
+Style/WordArray:
   Description: Use %w or %W for arrays of words.
   Enabled: true
   MinSize: 0
 
-MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Enabled: false
 
 ## Strings
 
 # Supports --auto-correct
-StringConversionInInterpolation:
+Lint/StringConversionInInterpolation:
   Description: Checks for Object#to_s usage in string interpolation.
   Enabled: true
 
 # Supports --auto-correct
-StringLiterals:
+Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   Enabled: true
   EnforcedStyle: double_quotes

--- a/configs/rubocop/other-lint.yml
+++ b/configs/rubocop/other-lint.yml
@@ -1,129 +1,129 @@
-AmbiguousOperator:
+Lint/AmbiguousOperator:
   Description: >-
      Checks for ambiguous operators in the first argument of a
      method invocation without parentheses.
   Enabled: true
 
-AmbiguousRegexpLiteral:
+Lint/AmbiguousRegexpLiteral:
   Description: >-
     Checks for ambiguous regexp literals in the first argument of
     a method invocation without parenthesis.
   Enabled: true
 
-AssignmentInCondition:
+Lint/AssignmentInCondition:
   Description: "Don't use assignment in conditions."
   Enabled: true
 
-ConditionPosition:
+Layout/ConditionPosition:
   Description: 'Checks for condition placed in a confusing position relative to the keyword.'
   Enabled: true
 
-Debugger:
+Lint/Debugger:
   Description: 'Check for debugger calls.'
   Enabled: true
 
-DeprecatedClassMethods:
+Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: true
 
-EmptyEnsure:
+Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
   Enabled: true
 
-EmptyInterpolation:
+Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: true
 
-EndInMethod:
+Lint/EndInMethod:
   Description: 'END blocks should not be placed inside method definitions.'
   Enabled: true
 
-EnsureReturn:
+Lint/EnsureReturn:
   Description: 'Never use return in an ensure block.'
   Enabled: true
 
-Eval:
+Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
   Enabled: true
 
-HandleExceptions:
+Lint/HandleExceptions:
   Description: "Don't suppress exception."
   Enabled: true
 
-LiteralAsCondition:
+Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true
 
-LiteralInInterpolation:
+Lint/LiteralInInterpolation:
   Description: 'Checks for literals used in interpolation.'
   Enabled: true
 
-Loop:
+Lint/Loop:
   Description: >-
      Use Kernel#loop with break rather than begin/end/until or
      begin/end/while for post-loop tests.
   Enabled: true
 
-ParenthesesAsGroupedExpression:
+Lint/ParenthesesAsGroupedExpression:
   Description: >-
      Checks for method calls with a space before the opening
      parenthesis.
   Enabled: true
 
-PercentStringArray:
+Lint/PercentStringArray:
   Description: Checks for unwanted commas and quotes in %w/%W literals eg %w('foo', “bar”).
   Enabled: true
 
-RequireParentheses:
+Lint/RequireParentheses:
   Description: >-
      Use parentheses in the method call to avoid confusion
      about precedence.
   Enabled: true
 
-ShadowingOuterLocalVariable:
+Lint/ShadowingOuterLocalVariable:
   Description: >-
      Do not use the same name as outer local variable
      for block arguments or block local variables.
   Enabled: true
 
-SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Description: >-
      Put a space between a method name and the first argument
      in a method call without parentheses.
   Enabled: true
 
-UnderscorePrefixedVariableName:
+Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
 
-UnusedMethodArgument:
+Lint/UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
   Enabled: true
 
-UnreachableCode:
+Lint/UnreachableCode:
   Description: 'Unreachable code.'
   Enabled: true
 
-UselessAccessModifier:
+Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
 
-UselessAssignment:
+Lint/UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'
   Enabled: true
 
-UselessComparison:
+Lint/UselessComparison:
   Description: 'Checks for comparison of something with itself.'
   Enabled: true
 
-UselessElseWithoutRescue:
+Lint/UselessElseWithoutRescue:
   Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
   Enabled: true
 
-UselessSetterCall:
+Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
   Enabled: true
 
-Void:
+Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: true

--- a/configs/rubocop/other-rails.yml
+++ b/configs/rubocop/other-rails.yml
@@ -5,34 +5,34 @@
 Rails:
   Enabled: false
 
-ActionFilter:
+Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: false
 
-Delegate:
+Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false
 
-HasAndBelongsToMany:
+Rails/HasAndBelongsToMany:
   Description: 'Prefer has_many :through to has_and_belongs_to_many.'
   Enabled: false
 
-Output:
+Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
   Enabled: false
 
-ReadWriteAttribute:
+Rails/ReadWriteAttribute:
   Description: 'Checks for read_attribute(:attr) and write_attribute(:attr, val).'
   Enabled: false
 
-ScopeArgs:
+Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: false
 
-Validation:
+Rails/Validation:
   Description: 'Use sexy validations.'
   Enabled: false
 
-SkipsModelValidations:
+Rails/SkipsModelValidations:
   Description: 'Avoid methods that skip model validations.'
   Enabled: false

--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -1,287 +1,287 @@
-AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   Enabled: true
   EnforcedStyle: outdent
 
-AccessorMethodName:
+Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 
-Alias:
+Style/Alias:
   Description: 'Use alias_method instead of alias.'
   Enabled: false
 
-AlignHash:
+Layout/AlignHash:
   Description: >-
     Align the elements of a hash literal if they span more than
     one line.
   Enabled: false
 
-AlignParameters:
+Layout/AlignParameters:
   Description: >-
     Align the parameters of a method call if they span more
     than one line.
   Enabled: false
 
-ArrayJoin:
+Style/ArrayJoin:
   Description: 'Use Array#join instead of Array#*.'
   Enabled: false
 
-AsciiComments:
+Style/AsciiComments:
   Description: 'Use only ascii symbols in comments.'
   Enabled: false
 
-AsciiIdentifiers:
+Naming/AsciiIdentifiers:
   Description: 'Use only ascii symbols in identifiers.'
   Enabled: false
 
-Attr:
+Style/Attr:
   Description: 'Checks for uses of Module#attr.'
   Enabled: false
 
-BeginBlock:
+Style/BeginBlock:
   Description: 'Avoid the use of BEGIN blocks.'
   Enabled: false
 
-BlockComments:
+Style/BlockComments:
   Description: 'Do not use block comments.'
   Enabled: false
 
-BlockNesting:
+Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   Enabled: false
 
-BlockDelimiters:
+Style/BlockDelimiters:
   Description: >-
     Avoid using {...} for multi-line blocks (multiline chaining is
     always ugly).
     Prefer {...} over do...end for single-line blocks.
   Enabled: false
 
-BracesAroundHashParameters:
+Style/BracesAroundHashParameters:
   Description: 'Enforce braces style inside hash parameters.'
   Enabled: true
 
-CaseEquality:
+Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
   Enabled: false
 
-CharacterLiteral:
+Style/CharacterLiteral:
   Description: 'Checks for uses of character literals.'
   Enabled: false
 
-ClassAndModuleChildren:
+Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
   Enabled: false
 
-ClassLength:
+Metrics/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
   Enabled: false
 
-CollectionMethods:
+Style/CollectionMethods:
   Description: 'Preferred collection methods.'
   Enabled: false
 
-ColonMethodCall:
+Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   Enabled: false
 
-CommentAnnotation:
+Style/CommentAnnotation:
   Description: >-
     Checks formatting of special comments
     (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
   Enabled: false
 
-CommentIndentation:
+Layout/CommentIndentation:
   Description: 'Indentation of comments.'
   Enabled: false
 
-CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Description: 'Avoid complex methods.'
   Enabled: false
 
-PreferredHashMethods:
+Style/PreferredHashMethods:
   Description: 'Checks for use of deprecated Hash methods.'
   Enabled: false
 
-Documentation:
+Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
 
-DotPosition:
+Layout/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
   Enabled: false
 
-DoubleNegation:
+Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   Enabled: false
 
-EachWithObject:
+Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
 
-EmptyLinesAroundAccessModifier:
+Layout/EmptyLinesAroundAccessModifier:
   Description: "Keep blank lines around access modifiers."
   Enabled: true
 
-EmptyLines:
+Layout/EmptyLines:
   Description: "Keeps track of empty lines around expression bodies."
   Enabled: false
 
-EmptyLiteral:
+Style/EmptyLiteral:
   Description: 'Prefer literals to Array.new/Hash.new/String.new.'
   Enabled: false
 
-Encoding:
+Style/Encoding:
   Description: 'Use UTF-8 as the source file encoding.'
   Enabled: false
 
-EndBlock:
+Style/EndBlock:
   Description: 'Avoid the use of END blocks.'
   Enabled: false
 
-EvenOdd:
+Style/EvenOdd:
   Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
   Enabled: false
 
-FileName:
+Naming/FileName:
   Description: 'Use snake_case for source file names.'
   Enabled: false
 
-FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   Enabled: false
 
-FormatString:
+Style/FormatString:
   Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
   Enabled: false
 
-GlobalVars:
+Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   Enabled: false
 
-GuardClause:
+Style/GuardClause:
   Description: 'Check for conditionals that can be replaced with guard clauses'
   Enabled: false
 
-IfWithSemicolon:
+Style/IfWithSemicolon:
   Description: 'Never use if x; .... Use the ternary operator instead.'
   Enabled: false
 
-IndentFirstArrayElement:
+Layout/IndentFirstArrayElement:
   Description: >-
     Checks the indentation of the first element in an array
     literal.
   Enabled: false
 
-IndentFirstHashElement:
+Layout/IndentFirstHashElement:
   Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: false
 
-Lambda:
+Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'
   Enabled: false
 
-LambdaCall:
+Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'
   Enabled: false
 
-LeadingCommentSpace:
+Layout/LeadingCommentSpace:
   Description: 'Comments should start with a space.'
   Enabled: false
 
-LineEndConcatenation:
+Style/LineEndConcatenation:
   Description: >-
     Use \ instead of + or << to concatenate two string literals at
     line end.
   Enabled: false
 
-MethodDefParentheses:
+Style/MethodDefParentheses:
   Description: >-
     Checks if the method definitions have or don't have
     parentheses.
   Enabled: false
 
-MethodLength:
+Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'
   Enabled: false
 
-ModuleFunction:
+Style/ModuleFunction:
   Description: 'Checks for usage of `extend self` in modules.'
   Enabled: false
 
-MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-NegatedIf:
+Style/NegatedIf:
   Description: >-
     Favor unless over if for negative conditions
     (or control flow or).
   Enabled: false
 
-NegatedWhile:
+Style/NegatedWhile:
   Description: 'Favor until over while for negative conditions.'
   Enabled: false
 
-Next:
+Style/Next:
   Description: 'Use `next` to skip iteration instead of a condition at the end.'
   Enabled: false
 
-NilComparison:
+Style/NilComparison:
   Description: 'Prefer x.nil? to x == nil.'
   Enabled: false
 
-NonNilCheck:
+Style/NonNilCheck:
   Description: 'Checks for redundant nil checks.'
   Enabled: false
 
-Not:
+Style/Not:
   Description: 'Use ! instead of not.'
   Enabled: false
 
-NumericLiterals:
+Style/NumericLiterals:
   Description: >-
     Add underscores to large numeric literals to improve their
     readability.
   Enabled: false
 
-ParameterLists:
+Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   Enabled: false
 
-PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   Description: 'Use `%`-literal delimiters consistently'
   Enabled: false
 
-PerlBackrefs:
+Style/PerlBackrefs:
   Description: 'Avoid Perl-style regex back references.'
   Enabled: false
 
-PredicateName:
+Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   Enabled: false
 
-Proc:
+Style/Proc:
   Description: 'Use proc instead of Proc.new.'
   Enabled: false
 
-RaiseArgs:
+Style/RaiseArgs:
   Description: 'Checks the arguments passed to raise/fail.'
   Enabled: false
 
-RedundantBegin:
+Style/RedundantBegin:
   Description: "Don't use begin blocks when they are not needed."
   Enabled: false
 
-RedundantException:
+Style/RedundantException:
   Description: "Checks for an obsolete RuntimeException argument in raise/fail."
   Enabled: false
 
-RedundantSelf:
+Style/RedundantSelf:
   Description: "Don't use self where it's not needed."
   Enabled: false
 
-RegexpLiteral:
+Style/RegexpLiteral:
   Description: >-
     Use %r for regular expressions matching more than
     `MaxSlashes` '/' characters.
@@ -289,7 +289,7 @@ RegexpLiteral:
     `MaxSlashes` '/' character.
   Enabled: false
 
-RescueModifier:
+Style/RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   Enabled: false
 
@@ -299,84 +299,84 @@ Style/SafeNavigation:
     existance of the object to safe navigation (`&.`).
   Enabled: false
 
-SelfAssignment:
+Style/SelfAssignment:
   Description: 'Checks for places where self-assignment shorthand should have been used.'
   Enabled: false
 
-Semicolon:
+Style/Semicolon:
   Description: "Don't use semicolons to terminate expressions."
   Enabled: false
 
-SignalException:
+Style/SignalException:
   Description: 'Checks for proper usage of fail and raise.'
   Enabled: false
 
-SingleLineBlockParams:
+Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'
   Enabled: false
 
-SingleLineMethods:
+Style/SingleLineMethods:
   Description: 'Avoid single-line methods.'
   Enabled: false
 
-SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Description: >-
     Checks that exactly one space is used between a method name
     and the first argument for method calls without parentheses.
   Enabled: false
 
-SpaceAroundKeyword:
+Layout/SpaceAroundKeyword:
   Description: 'Use spaces after if/elsif/unless/while/until/case/when.'
   Enabled: false
 
-SpaceAfterNot:
+Layout/SpaceAfterNot:
   Description: Tracks redundant space after the ! operator.
   Enabled: false
 
-SpaceBeforeComment:
+Layout/SpaceBeforeComment:
   Description: >-
     Checks for missing space between code and a comment on the
     same line.
   Enabled: false
 
-SpaceInsideBlockBraces:
+Layout/SpaceInsideBlockBraces:
   Description: >-
     Checks that block braces have or don't have surrounding space.
     For blocks taking parameters, checks that the left brace has
     or doesn't have trailing space.
   Enabled: true
 
-SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Description: "Use spaces inside hash literal braces - or don't."
   Enabled: true
 
-SpecialGlobalVars:
+Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   Enabled: false
 
-UnneededCapitalW:
+Style/UnneededCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: false
 
-CommandLiteral:
+Style/CommandLiteral:
   Description: 'Checks for %x when `` would do.'
   Enabled: false
 
-VariableInterpolation:
+Style/VariableInterpolation:
   Description: >-
     Don't interpolate global, instance and class variables
     directly in strings.
   Enabled: false
 
-WhenThen:
+Style/WhenThen:
   Description: 'Use when x then ... for one-line cases.'
   Enabled: false
 
-WhileUntilDo:
+Style/WhileUntilDo:
   Description: 'Checks for redundant do after while or until.'
   Enabled: false
 
-WhileUntilModifier:
+Style/WhileUntilModifier:
   Description: >-
     Favor modifier while/until usage when you have a
     single-line body.


### PR DESCRIPTION
- Fixes #127.
- Rubocop 0.75 outputs a load of `Warning` messages prior to running
  your checks if your configs don't have qualifying cop categories.
- These look like the following:
  /Users/user/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/govuk-lint-4.0.0/configs/rubocop/gds-ruby-styleguide.yml: Warning: no department given for BlockAlignment.