### PR TITLE
Update linter config for Rubocop 0.76

### DIFF
--- a/configs/rubocop/other-style.yml
+++ b/configs/rubocop/other-style.yml
@@ -354,7 +354,7 @@ Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   Enabled: false
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: false
 

--- a/govuk-lint.gemspec
+++ b/govuk-lint.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.3"
 
   spec.add_dependency "rubocop-rails", "~> 2"
-  spec.add_dependency "rubocop", "~> 0.72"
+  spec.add_dependency "rubocop", "~> 0.76"
   spec.add_dependency "rubocop-rspec", "~> 1.28"
   spec.add_dependency "scss_lint"
 end


### PR DESCRIPTION
Rubocop 0.76 (released 2019-10-28) includes a breaking change which renames Unneeded* cops to Redundant* (so `Style/UnneededCapitalW` becomes `Style/UnneededCapitalW`) ([1])

Repos that use the ‘other-style’ linting rules that are installing rubocop 0.76 are now failing because of this, with ‘Error: The `Style/UnneededCapitalW` cop has been renamed to `Style/RedundantCapitalW`.’ ([2])

Update the dependency to require rubocop 0.76 or above, and update the linter config to use the new cop name.

[1]: https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0760-2019-10-28
[2]: https://travis-ci.org/alphagov/tech-docs-gem/builds/604019618#L740