### PR TITLE
Add deprecation notice to repository and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.3.0
 
 * Deprecate govuk-ruby-lint
 * Deprecate govuk-scss-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Deprecate govuk-ruby-lint
+* Deprecate govuk-scss-lint
+
 # 4.2.0
 
 * Disable the Style/FormatStringToken cop.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# DEPRECATED
+
+This repository and Gem has been deprecated and is no longer supported.
+To lint Ruby and RSpec projects please consider using instead [rubocop-govuk][rubocop-govuk].
+To lint SASS projects please consider using [sass-lint][sass-lint].
+
 # GOV.UK Lint
 
 This repo configures various linters to comply with our [style guides][guides].
@@ -61,3 +67,5 @@ Auto-correction and `--diff` mode are unavailable.
 
 [guides]: https://github.com/alphagov/styleguides
 [rubocop]: https://github.com/bbatsov/rubocop
+[rubocop-govuk]: https://github.com/alphagov/rubocop-govuk
+[sass-lint]: https://github.com/sasstools/sass-lint

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # DEPRECATED
 
 This repository and Gem has been deprecated and is no longer supported.
-To lint Ruby and RSpec projects please consider using instead [rubocop-govuk][rubocop-govuk].
-To lint SASS projects please consider using [sass-lint][sass-lint].
+
+To lint Ruby and RSpec projects please consider using [rubocop][rubocop] with [rubocop-govuk][rubocop-govuk].
+
+To lint SASS projects please consider using [scss-lint][scss-lint] with [scss-lint-govuk][scss-lint-govuk].
+
+For guidance on upgrading to these tools see the [migrate from govuk-lint][migrate-guide] page in the developer docs.
 
 # GOV.UK Lint
 
@@ -66,6 +70,8 @@ default.
 Auto-correction and `--diff` mode are unavailable.
 
 [guides]: https://github.com/alphagov/styleguides
+[migrate-guide]: https://docs.publishing.service.gov.uk/manual/migrate-from-govuk-lint.html
 [rubocop]: https://github.com/bbatsov/rubocop
 [rubocop-govuk]: https://github.com/alphagov/rubocop-govuk
-[sass-lint]: https://github.com/sasstools/sass-lint
+[scss-lint]: https://github.com/sds/scss-lint
+[scss-lint-govuk]: https://github.com/alphagov/scss-lint-govuk

--- a/lib/govuk/lint/cli.rb
+++ b/lib/govuk/lint/cli.rb
@@ -8,6 +8,7 @@ module Govuk
   module Lint
     class CLI < RuboCop::CLI
       def run(args = ARGV)
+        warn "[DEPRECATION] `govuk-lint-ruby` is deprecated.  Please use `rubocop` with `rubocop-govuk` instead."
         config = ConfigFile.new
 
         args += [

--- a/lib/govuk/lint/sass_cli.rb
+++ b/lib/govuk/lint/sass_cli.rb
@@ -6,7 +6,7 @@ module Govuk
   module Lint
     class SassCLI < SCSSLint::CLI
       def run(args = ARGV)
-        warn "[DEPRECATION] `govuk-scss-lint` is deprecated.  Please use `sass-lint` instead."
+        warn "[DEPRECATION] `govuk-scss-lint` is deprecated.  Please use `scss-lint` with `scss-lint-govuk` instead."
         args += [
                   "--config",
                   File.join(Govuk::Lint::CONFIG_PATH, "scss_lint/gds-sass-styleguide.yml"),

--- a/lib/govuk/lint/sass_cli.rb
+++ b/lib/govuk/lint/sass_cli.rb
@@ -6,6 +6,7 @@ module Govuk
   module Lint
     class SassCLI < SCSSLint::CLI
       def run(args = ARGV)
+        warn "[DEPRECATION] `govuk-scss-lint` is deprecated.  Please use `sass-lint` instead."
         args += [
                   "--config",
                   File.join(Govuk::Lint::CONFIG_PATH, "scss_lint/gds-sass-styleguide.yml"),

--- a/lib/govuk/lint/version.rb
+++ b/lib/govuk/lint/version.rb
@@ -1,5 +1,5 @@
 module Govuk
   module Lint
-    VERSION = "4.2.0".freeze
+    VERSION = "4.3.0".freeze
   end
 end


### PR DESCRIPTION
This issues deprecation notices for the repository. This was discussed in [GOV.UK RFC 100](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-100-linting.md). Please use `rubocop-govuk` and `sass-lint-govuk` instead.